### PR TITLE
Feature/unique matches

### DIFF
--- a/alembic/versions/d2e08a0a3f7f_add_match_unique_key_column.py
+++ b/alembic/versions/d2e08a0a3f7f_add_match_unique_key_column.py
@@ -1,0 +1,24 @@
+"""add match unique_key column
+
+Revision ID: d2e08a0a3f7f
+Revises: 553bdd8a749f
+Create Date: 2020-11-03 17:40:23.083174
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = 'd2e08a0a3f7f'
+down_revision = '553bdd8a749f'
+branch_labels = None
+depends_on = None
+
+from alembic import op
+import sqlalchemy as sa
+
+def upgrade(engine_name):
+    print("Upgrading {}".format(engine_name))
+    op.add_column('gs_matches', sa.Column('unique_key', sa.String(50), nullable=True))
+
+def downgrade(engine_name):
+    print("Downgrading {}".format(engine_name))
+    op.drop_column('gs_matches', 'unique_key')

--- a/driftbase/api/matches.py
+++ b/driftbase/api/matches.py
@@ -141,23 +141,17 @@ class ActiveMatchesAPI(MethodView):
         return jsonify(ret)
 
 
-def ensure_unique_key(details, unique_key):
+def unique_key_in_use(unique_key):
     if unique_key:
         query = g.db.query(Match, Server)
         existing_unique_match = query.filter(Match.server_id == Server.server_id,
                                              Match.status.notin_(["ended", "completed"]),
-                                             Match.details["unique_key"].astext == unique_key,
+                                             Match.unique_key == unique_key,
                                              Server.status.in_(["started", "running", "active", "ready"]),
                                              Server.heartbeat_date >= utcnow() - datetime.timedelta(seconds=60)
                                              ).first()
-        if existing_unique_match is not None:
-            log.info("Tried to set the unique key '{}' of a battle when one already exists".format(unique_key))
-            abort(http_client.CONFLICT, description="An existing match with the same unique_key was found")
-        if details is None:
-            details = {"unique_key": unique_key}
-        else:
-            details["unique_key"] = unique_key
-    return details
+        return existing_unique_match is not None
+    return False
 
 
 def lock(redis):
@@ -219,12 +213,15 @@ class MatchesAPI(MethodView):
         args = request.json
         server_id = args.get("server_id")
         unique_key = args.get("unique_key")
+        details = args.get("details")
 
         with ExitStack() as stack:
             if unique_key:
                 stack.enter_context(lock(g.redis))
 
-            details = ensure_unique_key(args.get("details"), unique_key)
+            if unique_key_in_use(unique_key):
+                log.info("Tried to set the unique key '{}' of a battle when one already exists".format(unique_key))
+                abort(http_client.CONFLICT, description="An existing match with the same unique_key was found")
 
             match = Match(server_id=server_id,
                           num_players=args.get("num_players", 0),
@@ -236,6 +233,7 @@ class MatchesAPI(MethodView):
                           start_date=None,
                           match_statistics=args.get("match_statistics"),
                           details=details,
+                          unique_key=unique_key,
                           )
             g.db.add(match)
             g.db.flush()
@@ -293,13 +291,6 @@ class MatchAPI(MethodView):
 
         ret = match.as_dict()
         ret["url"] = url_for("matches.entry", match_id=match_id, _external=True)
-
-        # If details contains a unique_key, move it out to the root level
-        details = ret.get("details")
-        if details:
-            unique_key = details.pop("unique_key", None)
-            if unique_key:
-                ret["unique_key"] = unique_key
 
         server = g.db.query(Server).get(match.server_id)
         ret["server"] = None
@@ -378,13 +369,15 @@ class MatchAPI(MethodView):
                 log.warning("Trying to update a completed battle %d. Ignoring update", match_id)
                 abort(http_client.BAD_REQUEST, description="Battle has already been completed.")
 
-            current_unique_key = (match.details or {}).get("unique_key")
+            current_unique_key = match.unique_key
             if unique_key and current_unique_key:
                 log.info("Tried to update the unique key of a battle with a non-empty unique key '{}'->'{}'".format(
                     current_unique_key, unique_key))
                 abort(http_client.CONFLICT, description="Battle unique key must not be changed from a non-empty value")
 
-            details = ensure_unique_key(args.get("details"), unique_key)
+            if unique_key_in_use(unique_key):
+                log.info("Tried to set the unique key '{}' of a battle when one already exists".format(unique_key))
+                abort(http_client.CONFLICT, description="An existing match with the same unique_key was found")
 
             if match.status != new_status:
                 log.info("Changing status of match %s from '%s' to '%s'",
@@ -398,8 +391,6 @@ class MatchAPI(MethodView):
 
             for arg in args:
                 setattr(match, arg, args[arg])
-            if details:
-                match.details = details
             g.db.commit()
 
             resource_uri = url_for("matches.entry", match_id=match_id, _external=True)

--- a/driftbase/api/matches.py
+++ b/driftbase/api/matches.py
@@ -1,5 +1,6 @@
 import datetime
 import logging
+from contextlib import ExitStack
 
 from six.moves import http_client
 
@@ -150,12 +151,18 @@ def ensure_unique_key(details, unique_key):
                                              Server.heartbeat_date >= utcnow() - datetime.timedelta(seconds=60)
                                              ).first()
         if existing_unique_match is not None:
+            log.info("Tried to set the unique key '{}' of a battle when one already exists".format(unique_key))
             abort(http_client.CONFLICT, description="An existing match with the same unique_key was found")
         if details is None:
             details = {"unique_key": unique_key}
         else:
             details["unique_key"] = unique_key
     return details
+
+
+def lock(redis):
+    # Moving this into a separate function so systems test can mock it out.
+    return redis.lock("ensure_match_unique_key")
 
 
 @bp.route('', endpoint='list')
@@ -211,54 +218,59 @@ class MatchesAPI(MethodView):
         """
         args = request.json
         server_id = args.get("server_id")
+        unique_key = args.get("unique_key")
 
-        details = ensure_unique_key(args.get("details"), args.get("unique_key"))
+        with ExitStack() as stack:
+            if unique_key:
+                stack.enter_context(lock(g.redis))
 
-        match = Match(server_id=server_id,
-                      num_players=args.get("num_players", 0),
-                      max_players=args.get("max_players"),
-                      map_name=args.get("map_name"),
-                      game_mode=args.get("game_mode"),
-                      status=args.get("status"),
-                      status_date=utcnow(),
-                      start_date=None,
-                      match_statistics=args.get("match_statistics"),
-                      details=details,
-                      )
-        g.db.add(match)
-        g.db.flush()
-        # ! have to set this explicitly after the row is created
-        match.start_date = None
-        g.db.commit()
-        match_id = match.match_id
+            details = ensure_unique_key(args.get("details"), unique_key)
 
-        if args.get("num_teams"):
-            for i in range(args.get("num_teams")):
-                team = MatchTeam(match_id=match_id,
-                                 name="Team %s" % (i + 1)
-                                 )
-                g.db.add(team)
+            match = Match(server_id=server_id,
+                          num_players=args.get("num_players", 0),
+                          max_players=args.get("max_players"),
+                          map_name=args.get("map_name"),
+                          game_mode=args.get("game_mode"),
+                          status=args.get("status"),
+                          status_date=utcnow(),
+                          start_date=None,
+                          match_statistics=args.get("match_statistics"),
+                          details=details,
+                          )
+            g.db.add(match)
+            g.db.flush()
+            # ! have to set this explicitly after the row is created
+            match.start_date = None
             g.db.commit()
+            match_id = match.match_id
 
-        resource_uri = url_for("matches.entry", match_id=match_id, _external=True)
-        players_resource_uri = url_for("matches.players", match_id=match_id, _external=True)
-        response_header = {
-            "Location": resource_uri,
-        }
+            if args.get("num_teams"):
+                for i in range(args.get("num_teams")):
+                    team = MatchTeam(match_id=match_id,
+                                     name="Team %s" % (i + 1)
+                                     )
+                    g.db.add(team)
+                g.db.commit()
 
-        log.info("Created match %s for server %s", match_id, server_id)
-        log_match_event(match_id, None, "gameserver.match.created",
-                        details={"server_id": server_id})
+            resource_uri = url_for("matches.entry", match_id=match_id, _external=True)
+            players_resource_uri = url_for("matches.players", match_id=match_id, _external=True)
+            response_header = {
+                "Location": resource_uri,
+            }
 
-        try:
-            process_match_queue()
-        except Exception:
-            log.exception("Unable to process match queue")
+            log.info("Created match %s for server %s", match_id, server_id)
+            log_match_event(match_id, None, "gameserver.match.created",
+                            details={"server_id": server_id})
 
-        return jsonify({"match_id": match_id,
-                "url": resource_uri,
-                "players_url": players_resource_uri,
-                }), http_client.CREATED, response_header
+            try:
+                process_match_queue()
+            except Exception:
+                log.exception("Unable to process match queue")
+
+            return jsonify({"match_id": match_id,
+                    "url": resource_uri,
+                    "players_url": players_resource_uri,
+                    }), http_client.CREATED, response_header
 
 
 @bp.route('/<int:match_id>', endpoint='entry')
@@ -352,48 +364,55 @@ class MatchAPI(MethodView):
 
         log.debug("Updating battle %s", match_id)
         args = request.json
-        match = g.db.query(Match).get(match_id)
-        if not match:
-            abort(http_client.NOT_FOUND)
-        new_status = args.get("status")
-        if match.status == "completed":
-            log.warning("Trying to update a completed battle %d. Ignoring update", match_id)
-            abort(http_client.BAD_REQUEST, description="Battle has already been completed.")
-
         unique_key = args.get("unique_key")
-        current_unique_key = (match.details or {}).get("unique_key")
-        if unique_key and current_unique_key:
-            abort(http_client.CONFLICT, description="Battle unique key must not be changed from a non-empty value")
 
-        details = ensure_unique_key(args.get("details"), unique_key)
+        with ExitStack() as stack:
+            if unique_key:
+                stack.enter_context(lock(g.redis))
 
-        if match.status != new_status:
-            log.info("Changing status of match %s from '%s' to '%s'",
-                     match_id, match.status, args["status"])
-            if new_status == "started":
-                match.start_date = utcnow()
-            elif new_status == "completed":
-                match.end_date = utcnow()
-                # ! TODO: Set leave_date on matchplayers who are still in the match
-            match.status_date = utcnow()
+            match = g.db.query(Match).get(match_id)
+            if not match:
+                abort(http_client.NOT_FOUND)
+            new_status = args.get("status")
+            if match.status == "completed":
+                log.warning("Trying to update a completed battle %d. Ignoring update", match_id)
+                abort(http_client.BAD_REQUEST, description="Battle has already been completed.")
 
-        for arg in args:
-            setattr(match, arg, args[arg])
-        if details:
-            match.details = details
-        g.db.commit()
+            current_unique_key = (match.details or {}).get("unique_key")
+            if unique_key and current_unique_key:
+                log.info("Tried to update the unique key of a battle with a non-empty unique key '{}'->'{}'".format(
+                    current_unique_key, unique_key))
+                abort(http_client.CONFLICT, description="Battle unique key must not be changed from a non-empty value")
 
-        resource_uri = url_for("matches.entry", match_id=match_id, _external=True)
-        response_header = {
-            "Location": resource_uri,
-        }
-        ret = {"match_id": match_id,
-               "url": resource_uri,
-               }
+            details = ensure_unique_key(args.get("details"), unique_key)
 
-        log.info("Match %s has been updated.", match_id)
+            if match.status != new_status:
+                log.info("Changing status of match %s from '%s' to '%s'",
+                         match_id, match.status, args["status"])
+                if new_status == "started":
+                    match.start_date = utcnow()
+                elif new_status == "completed":
+                    match.end_date = utcnow()
+                    # ! TODO: Set leave_date on matchplayers who are still in the match
+                match.status_date = utcnow()
 
-        return jsonify(ret), http_client.OK, response_header
+            for arg in args:
+                setattr(match, arg, args[arg])
+            if details:
+                match.details = details
+            g.db.commit()
+
+            resource_uri = url_for("matches.entry", match_id=match_id, _external=True)
+            response_header = {
+                "Location": resource_uri,
+            }
+            ret = {"match_id": match_id,
+                   "url": resource_uri,
+                   }
+
+            log.info("Match %s has been updated.", match_id)
+
+            return jsonify(ret), http_client.OK, response_header
 
 
 @bp.route('/<int:match_id>/teams', endpoint='teams')

--- a/driftbase/models/db.py
+++ b/driftbase/models/db.py
@@ -348,6 +348,7 @@ class Match(ModelBase):
     match_statistics = Column(JSON, nullable=True)
     details = Column(JSON, nullable=True)
     status_date = Column(DateTime, nullable=True)
+    unique_key = Column(String(50), nullable=True)
 
 
 class MatchPlayer(ModelBase):

--- a/driftbase/utils/test_utils.py
+++ b/driftbase/utils/test_utils.py
@@ -70,7 +70,7 @@ class BaseMatchTest(BaseCloudkitTest):
         resp = self.post("/servers", data=data, expected_status_code=http_client.CREATED)
         return resp.json()
 
-    def _create_match(self, server_id=None, **kwargs):
+    def _create_match(self, server_id=None, expected_status_code=http_client.CREATED, **kwargs):
         if "service" not in self.current_user["roles"]:
             raise RuntimeError("Only service users can call this method")
         if not server_id:
@@ -85,9 +85,11 @@ class BaseMatchTest(BaseCloudkitTest):
                 "max_players": 2,
                 }
         data.update(**kwargs)
-        resp = self.post("/matches", data=data, expected_status_code=http_client.CREATED)
-        resp = self.get(resp.json()["url"])
-        return resp.json()
+        resp = self.post("/matches", data=data, expected_status_code=expected_status_code)
+        if resp:
+            resp = self.get(resp.json()["url"])
+            return resp.json()
+        return None
 
     def _filter_matches(self, resp, match_ids):
         return [m for m in resp.json() if m["match_id"] in match_ids]


### PR DESCRIPTION
- For various reasons we want to make sure all matches for a particular
  tenant are constrained to a single instance per an arbitrary
  unique key.
- The unique key is stored in the match table.
- One may only set the unique key when the match is created, or in a
  later update if the unique key was not previously set.
- Attempting to create two matches with the same unique key will result
  in a CONFLICT (409) regardless of how the update is made.
- A new match with the same unique key can only be created after the
  previous match has entered the ended or completed states, or the server
  has timed out (and is assumed dead).