### PR TITLE
Improve container shutdown behavior

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -45,4 +45,4 @@ USER uwsgi
 
 ENV PATH /home/uwsgi/.local/bin:$PATH
 
-CMD ["/home/uwsgi/.local/bin/uwsgi", "--ini", "/app/config/uwsgi.ini"]
+CMD ["/app/wrap-uwsgi.sh"]

--- a/wrap-uwsgi.sh
+++ b/wrap-uwsgi.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+
+# Use this as the entrypoint in docker and docker-compose.
+
+function tearDown() {
+  # Kubernetes will stop routing requests to a container that's shutting
+  # down, but that doesn't mean there's not one in flight between the router
+  # and the app, so we give that a second to arrive.
+  sleep 1
+  # If the pid-file is still around, then we're probably not running in
+  # Kubernetes, and we need to perform a graceful shutdown here.
+  # With Kubernetes, the commands below should be run in the preStop script instead.
+  if [[ -f /tmp/uwsgi.pid ]]; then
+    # Gracefully shut down uWSGI
+    echo q >/tmp/uwsgi-fifo
+    # Wait for uWSGI to exit for up to 30 seconds
+    # shellcheck disable=SC2046
+    timeout 30 tail -f /dev/null --pid=$(cat /tmp/uwsgi.pid)
+  fi
+  exit 0
+}
+
+# When run as PID 1 (init) bash doesn't react to signals unless we explicitly trap them.
+trap tearDown SIGTERM SIGINT
+
+# Launch uWSGI in the background, and wait for it to finish
+# If we just wait for uWSGI in the foreground, the trap above won't work
+/home/uwsgi/.local/bin/uwsgi --ini /app/config/uwsgi.ini &
+wait $!
+
+# When running in Kubernetes, we sleep a bit before exiting so the preStop
+# hook has a chance to exit cleanly.
+sleep 2


### PR DESCRIPTION
A container app is not running as part of an operating system in the traditional sense, it's really just running your one executable, and when that executable dies, so does the container. Thus containers don't have an init-process running as PID 1, it runs your app as PID 1.

Since Linux treats PID 1 special, it doesn't pass signals like TERM and INT to it, unless the app is designed to handle them.
It's fairly easy to react to signals in most programming languages, but uWSGI decided that convention is not for them. TERM is normally meant to gracefully shut down an app, giving it a chance to clean up. But uWSGI uses that to forcefully reload all processes immediately, and then keeps on running. INT is at least doing what we might expect, it kills the process, as does QUIT. HUP performs a graceful reload. But no signal anywhere allows us to gracefully shut down uWSGI, like TERM should've done. There is an option to make it die on TERM, but that's still not what we want.

uWSGI FIFO to the rescue. uWSGI creates a socket to which you can send commands, and 'q' does what we want. `echo q >/tmp/uwsgi-fifo` does the trick. But how do we translate TERM into that happening? uWSGI is already trapping TERM to mean force reload.

In Kubernetes, we solve this by providing a "preStop" hook, which gets called before the container is sent the TERM signal. It's a blocking call with a configurable timeout, and in our case it looks like this:

```
/bin/bash -c "sleep 1; echo q >/tmp/uwsgi-fifo; timeout 30 tail --pid=$(cat /tmp/uwsgi.pid) -f /dev/null"
```

OK, that's a handful, let's break it down:

- Wait for second so that we don't have requests still coming in over the network. Kubernetes has already stopped sending new requests at this point, but they might still be in flight.
- Write 'q' to the FIFO to tell uWSGI to start shutting down gracefully.
- Use the timeout command to wait for up to 30 seconds for tail to end. 30 seconds is a bit longer than the longest non-broken request is expected to take. This is mostly due to long-polls on the message queue.
- tail follows nothing forever (`-f /dev/null`), until the process with the ID that uWSGI has written to the file `/tmp/uwsgi.pid` terminates.

However, we now have a problem.

When PID 1 dies (uWSGI), the container is assumed to have crashed and died, and it gets killed on the spot. But we're still waiting in the "preStop" hook for the PID to disappear, and the kernel is way faster than us at detecting this. Hence the container and all processes get sent the KILL signal. This causes timeout to exit with error 137, which causes the preStop hook to fail, and the container gets killed by Kubernetes.

So, what? It's already killed, what's the problem?

Well, since we like to monitor out system, we keep an eye on all events coming from Kubernetes, and in this case we get a "pre stop hook failed" error, which we need to inspect and determine not to be harmful. We'd much rather know that an error is something we need to look into.

OK, but what to do then?

The trick here is to make uWSGI not be PID 1, but something else, so we can deal with the shutdown cleanly, and the magic in this case is rather simple, we change the container entry point to this:

```
/bin/bash -c "uwsgi; sleep 2"
```

This makes bash become PID 1, and once uWSGI stops, we sleep 2 seconds, which is more than enough to let the preStop hook detect that uWSGI is down, and exit cleanly. Kubernetes at this point sends TERM to the container, which bash ignores (remember it's PID 1), but since it's exiting anyway in a second, everything works as intended.

Great Scott! But what about Docker? There's no preStop hook there.

No, and it's not possible to completely eliminate problems, but it's possible to at least do a clean shutdown for all cases where there's no ongoing long-poll request. It's possible to handle long-poll as well, but you have to remember to pass an extended timeout to docker or docker-compose, since otherwise it will kill the container after 10 seconds.

OK, how?

We replace the entry point with the following script:

```
#!/bin/bash
function tearDown {
  sleep 1
  if [[ -f /tmp/uwsgi.pid ]]
  then
    echo q >/tmp/uwsgi-fifo
    timeout 30 tail -f /dev/null --pid=$(cat /tmp/uwsgi.pid)
  fi
  sleep 2
  exit 0
}
trap tearDown SIGTERM SIGINT
/home/uwsgi/.local/bin/uwsgi --ini /app/config/uwsgi.ini &
wait $!
```

This does mostly what the preStop hook did for Kubernetes in combination with moving uWSGI away from PID 1, but also adds a couple of extra bits.

We run a trap command to make sure that our script reacts to TERM and INT, by calling the `tearDown` function. We then start uWSGI in the background, and use wait to wait for it to finish. This last step is required, otherwise bash won't react to any signals until uWSGI exist, which, well, it just won't happen until Docker kills it.

Teardown does more or less exactly what the preStop hook did, with the added check for if the PID file exists at all. If it doesn't we're probably running in Kubernetes and preStop shut things down, so we can just exit right away. Otherwise we do the FIFO/timout/tail dance we learned about before, plus we wait a little bit to make sure preStop has actually finished before we exit.