### PR TITLE
Bugfix/message expiration

### DIFF
--- a/driftbase/api/messages.py
+++ b/driftbase/api/messages.py
@@ -245,6 +245,9 @@ class MessagesQueueAPI(MethodView):
 
 
 def _add_message(exchange, exchange_id, queue, payload, expire_seconds=None):
+    if not is_key_legal(exchange) or not is_key_legal(queue):
+        abort(http_client.BAD_REQUEST, message="Exchange or Queue name is invalid.")
+
     expire_seconds = expire_seconds or DEFAULT_EXPIRE_SECONDS
     message_id = str(uuid.uuid4())
     message_number = incr_message_number(exchange, exchange_id)
@@ -261,8 +264,6 @@ def _add_message(exchange, exchange_id, queue, payload, expire_seconds=None):
         "exchange": exchange,
         "exchange_id": exchange_id,
     }
-    if not is_key_legal(exchange) or not is_key_legal(queue):
-        abort(http_client.BAD_REQUEST, message="Exchange or Queue name is invalid.")
 
     key = "messages:%s-%s" % (exchange, exchange_id)
     val = json.dumps(message, default=json_serial)

--- a/driftbase/api/messages.py
+++ b/driftbase/api/messages.py
@@ -95,7 +95,7 @@ def fetch_messages(exchange, exchange_id, min_message_number=0, rows=None):
         i += 1
         if curr_message_number < min_message_number:
             break
-        expires = datetime.datetime.fromisoformat(message["expires"][:-1])
+        expires = datetime.datetime.fromisoformat(message["expires"][:-1]) # remove trailing 'Z'
         if expires > utcnow():
             messages.append(message)
             log.info("Message %s ('%s') has been retrieved from queue '%s' in "
@@ -106,7 +106,7 @@ def fetch_messages(exchange, exchange_id, min_message_number=0, rows=None):
             if rows and len(messages) >= rows:
                 break
         else:
-            log.info("Message %s ('%s') has been expired from queue '%s' in "
+            log.info("Expired message %s ('%s') was removed from queue '%s' in "
                      "exchange '%s-%s' by player %s",
                      message["message_number"], message["message_id"],
                      message["queue"], exchange, exchange_id, my_player_id)

--- a/driftbase/api/messages.py
+++ b/driftbase/api/messages.py
@@ -69,8 +69,7 @@ def incr_message_number(exchange, exchange_id):
 
 def fetch_messages(exchange, exchange_id, min_message_number=0, rows=None):
     messages = []
-    key = "messages:%s-%s" % (exchange, exchange_id)
-    redis_key = g.redis.make_key(key)
+    redis_key = g.redis.make_key("messages:%s-%s" % (exchange, exchange_id))
     seen_key = "messages:seen:%s-%s" % (exchange, exchange_id)
     redis_seen_key = g.redis.make_key(seen_key)
     my_player_id = None


### PR DESCRIPTION
Fix issues with message and exchange expiration

- Don't expire the entire exchange based on the last message
- Set the same expiration time for the exchange, top message, and last seen
- Fix semantics of seen, as it used to be the next message you wanted to see
