### PR TITLE
Feature/player names in party invites

### DIFF
--- a/driftbase/api/parties.py
+++ b/driftbase/api/parties.py
@@ -156,6 +156,7 @@ class PartyInvitesAPI(MethodView):
     @bp_parties.response(http_client.CREATED, PartyInvitesResponseSchema)
     def post(self, args):
         my_player_id = current_user['player_id']
+        my_player = g.db.query(CorePlayer.player_name).filter(CorePlayer.player_id == my_player_id).first()
         player_id = args.get('player_id')
         if my_player_id == player_id:
             abort(http_client.BAD_REQUEST, message="You can't invite yourself to a party")
@@ -179,6 +180,7 @@ class PartyInvitesAPI(MethodView):
                              "event": "invite",
                              "invite_id": invite_id,
                              "invite_url": resource_uri,
+                             "inviting_player_name": my_player.player_name,
                              "inviting_player_id": my_player_id,
                              "inviting_player_url": url_for("players.entry", player_id=my_player_id, _external=True),
                          })

--- a/driftbase/tests/test_parties.py
+++ b/driftbase/tests/test_parties.py
@@ -41,6 +41,7 @@ class PartiesTest(BaseCloudkitTest):
         # Check g1 gets a notification about the invite
         self.auth(username=guest_user_1)
         g1_notification, g1_message_number = self.get_party_notification('invite')
+        self.assertEqual(g1_notification['inviting_player_name'], host_user)
         self.assertEqual(g1_notification['inviting_player_id'], host_id)
         self.assertEqual(g1_notification['invite_url'], invite['url'])
 
@@ -67,6 +68,7 @@ class PartiesTest(BaseCloudkitTest):
         # Check g2 gets a notification about the invite
         self.auth(username=guest_user_2)
         g2_notification, g2_message_number = self.get_party_notification('invite')
+        self.assertEqual(g2_notification['inviting_player_name'], host_user)
         self.assertEqual(g2_notification['inviting_player_id'], host_id)
         self.assertEqual(g2_notification['invite_url'], invite['url'])
 


### PR DESCRIPTION
Pass the inviting player's name in the party invite notification, to save the client from having to make a manual lookup