### PR TITLE
Make DataDog patch logging to include trace spans

### DIFF
--- a/driftbase/flask/driftbaseapp.py
+++ b/driftbase/flask/driftbaseapp.py
@@ -6,5 +6,11 @@ monkey.patch_all()
 from psycogreen.gevent import patch_psycopg
 patch_psycopg()
 
-import drift.contrib.flask.datadogapp
-app = drift.contrib.flask.datadogapp.app
+import os
+
+if os.environ.get('ENABLE_DATADOG_APM', '0') == '1':
+    import ddtrace
+    ddtrace.patch_all(logging=True)
+
+from drift.flaskfactory import drift_app
+app = drift_app()


### PR DESCRIPTION
To correlate logs and traces, the trace and span IDs need to be included in the logs, and this seem to do the trick.

Moved the dd setup from drift, since these patching calls need to be done in a very specific order, and this gives us more control