### PR TITLE
Feature/messages as redis streams

### DIFF
--- a/driftbase/api/friendships.py
+++ b/driftbase/api/friendships.py
@@ -14,7 +14,7 @@ from sqlalchemy.orm import aliased
 
 from driftbase.models.db import Friendship, FriendInvite, CorePlayer
 from driftbase.schemas.friendships import InviteSchema, FriendRequestSchema
-from driftbase.api.messages import post_message
+from driftbase.messages import post_message
 
 DEFAULT_INVITE_EXPIRATION_TIME_SECONDS = 60 * 60 * 1
 

--- a/driftbase/api/messages.py
+++ b/driftbase/api/messages.py
@@ -4,7 +4,6 @@
 
 import copy
 
-import collections
 import datetime
 import gevent
 import http.client as http_client
@@ -12,12 +11,11 @@ import json
 import logging
 import marshmallow as ma
 import operator
-import sys
-import uuid
 from flask import g, url_for, stream_with_context, Response, jsonify
 from flask.views import MethodView
 from flask_smorest import Blueprint, abort
 
+import driftbase.messages
 from drift.core.extensions.jwt import current_user
 from drift.core.extensions.urlregistry import Endpoints
 
@@ -33,129 +31,20 @@ def drift_init_extension(app, api, **kwargs):
     endpoints.init_app(app)
 
 
-# messages expire in a day by default
-DEFAULT_EXPIRE_SECONDS = 60 * 60 * 24
-# keep the top message around for a month
-MESSAGE_EXCHANGE_TTL = 60 * 60 * 24 * 30
-
-
 # for mocking
 def utcnow():
     return datetime.datetime.utcnow()
 
 
-def json_serial(obj):
-    """JSON serializer for objects not serializable by default json code"""
-    if isinstance(obj, datetime.datetime):
-        serial = obj.isoformat()
-        return serial
-    raise TypeError("Type not serializable")
-
-
-def is_key_legal(key):
-    if len(key) > 64:
-        return False
-    if ":" in key:
-        return False
-    return True
-
-
-def incr_message_number(exchange, exchange_id):
-    k = "top_message_number:%s:%s" % (exchange, exchange_id)
-    val = g.redis.incr(k, expire=MESSAGE_EXCHANGE_TTL)
-    seen = latest_seen(exchange, exchange_id)
-    if seen >= val:
-        adjustment = (seen - val) + 1
-        log.warning(
-            f"Latest seen message is at {seen} but next top message number would be {val} and would thus never be seen. Adjusting next message number to {val + adjustment}")
-        val = g.redis.incr(k, adjustment, expire=MESSAGE_EXCHANGE_TTL)
-    return int(val)
-
-
-def latest_seen(exchange, exchange_id):
-    redis_seen_key = g.redis.make_key("messages:seen:%s-%s" % (exchange, exchange_id))
-    seen = g.redis.conn.get(redis_seen_key)
-    return int(seen) if seen else 0
-
-
-def fetch_messages(exchange, exchange_id, min_message_number=0, rows=None):
-    messages = []
-    redis_messages_key = g.redis.make_key("messages:%s-%s" % (exchange, exchange_id))
-    redis_seen_key = g.redis.make_key("messages:seen:%s-%s" % (exchange, exchange_id))
-    my_player_id = None
-    if current_user:
-        my_player_id = current_user["player_id"]
-    i = 1
-
-    seen_message_number = g.redis.conn.get(redis_seen_key)
-    if min_message_number == 1 and seen_message_number:
-        min_message_number = int(seen_message_number) + 1
-    else:
-        g.redis.conn.setex(redis_seen_key, MESSAGE_EXCHANGE_TTL, min_message_number - 1)
-
-    curr_message_number = sys.maxsize
-    highest_processed_message_number = 0
-    g.redis.conn.expire(redis_messages_key, MESSAGE_EXCHANGE_TTL)
-    while curr_message_number >= min_message_number:
-        all_contents = g.redis.conn.lrange(redis_messages_key, -i, -i)
-        if not all_contents:
-            break
-        contents = all_contents[0]
-        message = json.loads(contents)
-        curr_message_number = message["message_number"]
-        i += 1
-        if curr_message_number < min_message_number:
-            break
-        highest_processed_message_number = max(curr_message_number, highest_processed_message_number)
-        expires = datetime.datetime.fromisoformat(message["expires"][:-1])  # remove trailing 'Z'
-        if expires > utcnow():
-            messages.append(message)
-            log.debug("Message %s ('%s') has been retrieved from queue '%s' in "
-                      "exchange '%s-%s' by player %s",
-                      message["message_number"], message["message_id"],
-                      message["queue"], exchange, exchange_id, my_player_id)
-
-            if rows and len(messages) >= rows:
-                break
-        else:
-            log.debug("Expired message %s ('%s') was removed from queue '%s' in "
-                      "exchange '%s-%s' by player %s",
-                      message["message_number"], message["message_id"],
-                      message["queue"], exchange, exchange_id, my_player_id)
-
-    # If there were only expired messages, make sure we skip those next time
-    if len(messages) == 0 and highest_processed_message_number > 0:
-        g.redis.conn.setex(redis_seen_key, MESSAGE_EXCHANGE_TTL, highest_processed_message_number)
-
-    messages.sort(key=operator.itemgetter("message_number"), reverse=True)
-    rows = rows or len(messages)
-    ret = collections.defaultdict(list)
-    for m in messages[:rows]:
-        ret[m["queue"]].append(m)
-    return ret
-
-
-def is_service():
-    ret = False
-    if current_user and 'service' in current_user['roles']:
-        ret = True
-    return ret
-
-
-def check_can_use_exchange(exchange, exchange_id, read=False):
-    # service users have unrestricted access to all exchanges
-    if is_service():
-        return True
-
-    # players can only use player exchanges
-    if exchange != "players":
-        abort(http_client.BAD_REQUEST, message="Only service users can use exchange '%s'" % exchange)
-
-    # players can only read from their own exchanges but can write to others
-    if read:
-        if not current_user or current_user["player_id"] != exchange_id:
-            abort(http_client.BAD_REQUEST,
-                  message="You can only read from an exchange that belongs to you!")
+def _patch_messages(messages):
+    """Return all messages patched to match the old API"""
+    patched = {}
+    for k, v in iter(messages.items()):
+        for e in v:
+            e.update({'message_number': int(e['message_id'])})
+        v.sort(key=operator.itemgetter("message_number"), reverse=True)
+        patched[k] = v
+    return patched
 
 
 class MessagesExchangeGetQuerySchema(ma.Schema):
@@ -170,20 +59,21 @@ class MessagesExchangeAPI(MethodView):
 
     @bp.arguments(MessagesExchangeGetQuerySchema, location='query')
     def get(self, args, exchange, exchange_id):
-        check_can_use_exchange(exchange, exchange_id, read=True)
+        driftbase.messages.check_can_use_exchange(exchange, exchange_id, read=True)
 
         timeout = args['timeout']
-        min_message_number = args.get('messages_after') + 1
+        messages_after = str(args.get('messages_after'))
         rows = args.get('rows')
         if rows:
-            rows = int(rows)
+            # Old API read rows from newest to oldest
+            rows = -int(rows)
 
         my_player_id = None
         if current_user:
             my_player_id = current_user["player_id"]
 
         # players can only use player exchanges
-        if exchange != "players" and not is_service():
+        if exchange != "players" and not driftbase.messages.is_service():
             abort(http_client.BAD_REQUEST,
                   message="Only service users can use exchange '%s'" % exchange)
 
@@ -199,12 +89,13 @@ class MessagesExchangeAPI(MethodView):
                 yield " "
                 while 1:
                     try:
-                        messages = fetch_messages(exchange, exchange_id, min_message_number, rows)
-                        if messages:
+                        streamer_messages = driftbase.messages.fetch_messages(exchange, exchange_id, messages_after,
+                                                                              rows)
+                        if streamer_messages:
                             log.debug("[%s/%s] Returning messages after %.1f seconds",
                                       my_player_id, exchange_full_name,
                                       (utcnow() - start_time).total_seconds())
-                            yield json.dumps(messages, default=json_serial)
+                            yield json.dumps(_patch_messages(streamer_messages), default=driftbase.messages.json_serial)
                             return
                         elif utcnow() > poll_timeout:
                             log.debug("[%s/%s] Poll timeout with no messages after %.1f seconds",
@@ -221,8 +112,8 @@ class MessagesExchangeAPI(MethodView):
 
             return Response(stream_with_context(streamer()), mimetype="application/json")
         else:
-            messages = fetch_messages(exchange, exchange_id, min_message_number, rows)
-            return jsonify(messages)
+            messages = driftbase.messages.fetch_messages(exchange, exchange_id, messages_after, rows)
+            return jsonify(_patch_messages(messages))
 
 
 class MessagesQueuePostArgs(ma.Schema):
@@ -235,16 +126,23 @@ class MessagesQueueAPI(MethodView):
 
     @bp.arguments(MessagesQueuePostArgs)
     def post(self, args, exchange, exchange_id, queue):
-        check_can_use_exchange(exchange, exchange_id, read=False)
-        expire_seconds = args.get("expire") or DEFAULT_EXPIRE_SECONDS
+        driftbase.messages.check_can_use_exchange(exchange, exchange_id, read=False)
+        expire_seconds = args.get("expire") or driftbase.messages.DEFAULT_EXPIRE_SECONDS
 
-        message = post_message(
+        message = driftbase.messages.post_message(
             exchange=exchange,
             exchange_id=exchange_id,
             queue=queue,
             payload=args["message"],
             expire_seconds=expire_seconds,
         )
+
+        # Fill in legacy data the new API doesn't care about
+        message['exchange'] = exchange
+        message['exchange_id'] = exchange_id
+        message['message_number'] = int(message['message_id'])
+        message['queue'] = queue
+        message['payload'] = args['message']
 
         log.debug(
             "Message %s ('%s') has been added to queue '%s' in exchange "
@@ -268,46 +166,11 @@ class MessagesQueueAPI(MethodView):
         return jsonify(ret)
 
 
-def post_message(exchange, exchange_id, queue, payload, expire_seconds=None, sender_system=False):
-    if not is_key_legal(exchange) or not is_key_legal(queue):
-        abort(http_client.BAD_REQUEST, message="Exchange or Queue name is invalid.")
-
-    expire_seconds = expire_seconds or DEFAULT_EXPIRE_SECONDS
-    message_id = str(uuid.uuid4())
-    timestamp = utcnow()
-    expires = timestamp + datetime.timedelta(seconds=expire_seconds)
-
-    lock_key = "lockmessage_%s_%s" % (exchange, exchange_id)
-    with g.redis.lock(lock_key):
-        message_number = incr_message_number(exchange, exchange_id)
-        message = {
-            "timestamp": timestamp.isoformat() + "Z",
-            "expires": expires.isoformat() + "Z",
-            "sender_id": 0 if sender_system else current_user["player_id"],
-            "message_id": message_id,
-            "message_number": message_number,
-            "payload": payload,
-            "queue": queue,
-            "exchange": exchange,
-            "exchange_id": exchange_id,
-        }
-
-        key = "messages:%s-%s" % (exchange, exchange_id)
-        val = json.dumps(message, default=json_serial)
-        log.info(
-            f"Inserting message {message_id} with message number {message_number} into {exchange} exchange for {exchange_id}")
-        k = g.redis.make_key(key)
-        g.redis.conn.rpush(k, val)
-        g.redis.conn.expire(k, MESSAGE_EXCHANGE_TTL)
-
-    return message
-
-
 @bp.route('/<string:exchange>/<int:exchange_id>/<string:queue>/<string:message_id>', endpoint='message')
 class MessageQueueAPI(MethodView):
 
     def get(self, exchange, exchange_id, queue, message_id):
-        check_can_use_exchange(exchange, exchange_id, read=True)
+        driftbase.messages.check_can_use_exchange(exchange, exchange_id, read=True)
 
         key = "messages:%s-%s:%s:%s" % (exchange, exchange_id, queue, message_id)
         val = g.redis.get(key)

--- a/driftbase/api/parties.py
+++ b/driftbase/api/parties.py
@@ -9,7 +9,7 @@ from flask.views import MethodView
 from flask_smorest import Blueprint, abort
 import http.client as http_client
 
-from driftbase.api.messages import post_message
+from driftbase.messages import post_message
 from driftbase.models.db import CorePlayer
 from driftbase.parties import accept_party_invite, get_player_party, get_party_members, leave_party, disband_party, \
     create_party_invite, decline_party_invite

--- a/driftbase/flexmatch.py
+++ b/driftbase/flexmatch.py
@@ -7,7 +7,7 @@ from botocore.exceptions import ClientError, ParamValidationError
 from flask import g
 from aws_assume_role_lib import assume_role
 from driftbase.parties import get_player_party, get_party_members
-from driftbase.api.messages import post_message
+from driftbase.messages import post_message
 
 from driftbase.resources.flexmatch import TIER_DEFAULTS
 

--- a/driftbase/messages.py
+++ b/driftbase/messages.py
@@ -1,0 +1,168 @@
+from http import client as http_client
+
+import collections
+import datetime
+import functools
+import json
+import logging
+import textwrap
+from flask import g
+from webargs.flaskparser import abort
+
+from drift.core.extensions.jwt import current_user
+
+log = logging.getLogger(__name__)
+
+# messages expire in a day by default
+DEFAULT_EXPIRE_SECONDS = 60 * 60 * 24
+# prune a player's message list if they're not listening
+MAX_PENDING_MESSAGES = 100
+
+
+# for mocking
+def utcnow():
+    return datetime.datetime.utcnow()
+
+
+def json_serial(obj):
+    """JSON serializer for objects not serializable by default json code"""
+    if isinstance(obj, datetime.datetime):
+        serial = obj.isoformat()
+        return serial
+    raise TypeError("Type not serializable")
+
+
+def is_key_legal(key):
+    if len(key) > 64:
+        return False
+    if ":" in key:
+        return False
+    return True
+
+
+def fetch_messages(exchange, exchange_id, messages_after_id=None, rows=None):
+    my_player_id = None
+    if current_user:
+        my_player_id = current_user["player_id"]
+
+    redis_messages_key = g.redis.make_key(f"messages:{exchange}:{exchange_id}:")
+    redis_seen_key = g.redis.make_key(f"messages:seen:{exchange}:")
+
+    seen_message_id = g.redis.conn.hget(redis_seen_key, exchange_id)
+    if messages_after_id == '0' and seen_message_id:
+        messages_after_id = seen_message_id
+    else:
+        g.redis.conn.hset(redis_seen_key, exchange_id, messages_after_id)
+
+    now = utcnow()
+    messages = []
+    expired_ids = []
+    highest_processed_message_id = '0'
+    from_message_id = _next_message_id(messages_after_id)
+
+    # if rows is negative, read in reverse, to satisfy old API
+    if not rows or rows >= 0:
+        content = g.redis.conn.xrange(redis_messages_key, min=from_message_id, max='+', count=rows)
+    else:
+        content = g.redis.conn.xrevrange(redis_messages_key, min=from_message_id, max='+', count=-rows)
+    if len(content):
+        for message_id, message in content:
+            # Redis will append '-0' to custom IDs too, so make sure we remove it here
+            message_id = message_id.split('-')[0]
+            message['payload'] = json.loads(message['payload'])
+            message['message_id'] = message_id
+            highest_processed_message_id = message_id
+            expires = datetime.datetime.fromisoformat(message["expires"][:-1])  # remove trailing 'Z'
+            if expires > now:
+                messages.append(message)
+                log.debug("Message %s has been retrieved from queue '%s' in "
+                          "exchange '%s:%s' by player %s",
+                          message['message_id'],
+                          message['queue'], exchange, exchange_id, my_player_id)
+            else:
+                expired_ids += message_id
+                log.debug("Expired message %s was removed from queue '%s' in "
+                          "exchange '%s:%s' by player %s",
+                          message['message_id'],
+                          message['queue'], exchange, exchange_id, my_player_id)
+
+    with g.redis.conn.pipeline() as pipe:
+        # If there were only expired messages, make sure we skip those next time
+        if len(messages) == 0 and highest_processed_message_id != '0':
+            pipe.hset(redis_seen_key, exchange_id, highest_processed_message_id)
+
+        # Delete expired messages
+        if expired_ids:
+            pipe.xdel(redis_messages_key, expired_ids)
+        pipe.execute()
+
+    result = collections.defaultdict(list)
+    for m in messages:
+        result[m['queue']].append(m)
+    return result
+
+
+def is_service():
+    ret = False
+    if current_user and 'service' in current_user['roles']:
+        ret = True
+    return ret
+
+
+def check_can_use_exchange(exchange, exchange_id, read=False):
+    # service users have unrestricted access to all exchanges
+    if is_service():
+        return True
+
+    # players can only use player exchanges
+    if exchange != "players":
+        abort(http_client.BAD_REQUEST, message="Only service users can use exchange '%s'" % exchange)
+
+    # players can only read from their own exchanges but can write to others
+    if read:
+        if not current_user or current_user["player_id"] != exchange_id:
+            abort(http_client.BAD_REQUEST,
+                  message="You can only read from an exchange that belongs to you!")
+
+
+@functools.lru_cache
+def _get_add_message_script():
+    return g.redis.conn.register_script(textwrap.dedent(f"""
+        local id = redis.call('INCRBY', KEYS[2], 1)
+        redis.call('XADD', KEYS[1], 'MAXLEN', '~', {MAX_PENDING_MESSAGES}, id, unpack(ARGV))
+        return tostring(id)
+        """))
+
+
+def post_message(exchange, exchange_id, queue, payload, expire_seconds=None, sender_system=False):
+    if not is_key_legal(exchange) or not is_key_legal(queue):
+        abort(http_client.BAD_REQUEST, message="Exchange or Queue name is invalid.")
+
+    expire_seconds = expire_seconds or DEFAULT_EXPIRE_SECONDS
+    timestamp = utcnow()
+    expires = timestamp + datetime.timedelta(seconds=expire_seconds)
+    message = {
+        'timestamp': timestamp.isoformat() + "Z",
+        'expires': expires.isoformat() + "Z",
+        'sender_id': 0 if sender_system else current_user["player_id"],
+        'payload': json.dumps(payload, default=json_serial),
+        'queue': queue,
+        'exchange': exchange,
+        'exchange_id': exchange_id,
+    }
+
+    pieces = []
+    for pair in iter(message.items()):
+        pieces.extend(pair)
+    message_id = _get_add_message_script()(keys=[g.redis.make_key(f"messages:{exchange}:{exchange_id}:"),
+                                                 g.redis.make_key(f"messages:{exchange}:{exchange_id}:next:")],
+                                           args=pieces)
+
+    return {
+        'message_id': message_id,
+    }
+
+
+def _next_message_id(message_id: str) -> str:
+    """ Return the minimum valid increment to the passed in message_id """
+    return str(int(message_id) + 1)

--- a/driftbase/schemas/players.py
+++ b/driftbase/schemas/players.py
@@ -40,6 +40,9 @@ class PlayerSchema(SQLAlchemyAutoSchema):
     messagequeue_url = fields.Str(
         description="Fully qualified URL of the players' message queue resource"
     )
+    messagequeue2_url = fields.Str(
+        description="Fully qualified URL of the players' message queue resource"
+    )
     messages_url = Url(
         'messages.exchange',
         doc="Fully qualified URL of the players' messages resource",

--- a/driftbase/tests/test_messages.py
+++ b/driftbase/tests/test_messages.py
@@ -1,5 +1,5 @@
+import http.client
 import urllib
-import http.client as http_client
 
 from driftbase.utils.test_utils import BaseCloudkitTest
 
@@ -9,56 +9,57 @@ class MessagesTest(BaseCloudkitTest):
     Tests for the /messages endpoints
     """
 
-    def test_messages_send(self):
-        player_receiver = self.make_player()
-        player_receiver_endpoint = self.endpoints["my_player"]
+    def make_player_message_endpoint_and_session(self):
+        self.make_player()
+        return self.endpoints["my_player"], self.headers
+
+    def get_messages_url(self, player_receiver_endpoint):
         r = self.get(player_receiver_endpoint)
         messagequeue_url_template = r.json()["messagequeue_url"]
         messagequeue_url_template = urllib.parse.unquote(messagequeue_url_template)
         messages_url = r.json()["messages_url"]
+        return messagequeue_url_template, messages_url
+
+    def test_messages_send(self):
+        player_receiver_endpoint, _ = self.make_player_message_endpoint_and_session()
+        messagequeue_url_template, messages_url = self.get_messages_url(player_receiver_endpoint)
 
         player_sender = self.make_player()
 
         messagequeue_url = messagequeue_url_template.format(queue="testqueue")
         data = {"message": {"Hello": "World"}}
-        r = self.post(messagequeue_url, data=data)
+        r = self.post(messagequeue_url, data=data, expected_status_code=http.client.OK)
         message_url = r.json()["url"]
-        self.assertIn("payload", r.json())
-        self.assertIn("Hello", r.json()["payload"])
 
         # we should not be able to read the message back, only the recipient can do that
-        r = self.get(message_url, expected_status_code=http_client.BAD_REQUEST)
+        r = self.get(message_url, expected_status_code=http.client.BAD_REQUEST)
         self.assertIn("that belongs to you", r.json()["error"]["description"])
 
         # we should not be able to read anything from the exchange either
-        r = self.get(messages_url, expected_status_code=http_client.BAD_REQUEST)
+        r = self.get(messages_url, expected_status_code=http.client.BAD_REQUEST)
         self.assertIn("that belongs to you", r.json()["error"]["description"])
 
     def test_messages_receive(self):
-        player_receiver = self.make_player()
-        receiver_headers = self.headers
-
-        player_receiver_endpoint = self.endpoints["my_player"]
-        r = self.get(player_receiver_endpoint).json()
-        messagequeue_url_template = r["messagequeue_url"]
-        messagequeue_url_template = urllib.parse.unquote(messagequeue_url_template)
-        messages_url = r["messages_url"]
+        player_receiver_endpoint, receiver_headers = self.make_player_message_endpoint_and_session()
+        messagequeue_url_template, messages_url = self.get_messages_url(player_receiver_endpoint)
 
         # send a message from another player
         player_sender = self.make_player()
         messagequeue_url = messagequeue_url_template.format(queue="testqueue")
         data = {
-            "message" : {"Hello": "World"}
+            "message": {"Hello": "World"}
         }
-        r = self.post(messagequeue_url, data=data).json()
+        r = self.post(messagequeue_url, data=data, expected_status_code=http.client.OK).json()
         message_url = r["url"]
 
         # switch to the receiver player
         self.headers = receiver_headers
 
         # Attempt to fetch just the message we just sent
-        # NOTE: Fetching a particular message simply does not work and probably hasn't for a while
-        #r = self.get(message_url).json()
+        r = self.get(message_url).json()
+        self.assertEqual(r["queue"], "testqueue")
+        self.assertIn("payload", r)
+        self.assertIn("Hello", r["payload"])
 
         # get all the messages for the player
         r = self.get(messages_url).json()
@@ -71,14 +72,8 @@ class MessagesTest(BaseCloudkitTest):
         self.assertEqual(self.get(messages_url).json(), r)
 
     def test_messages_rows(self):
-        player_receiver = self.make_player()
-        receiver_headers = self.headers
-
-        player_receiver_endpoint = self.endpoints["my_player"]
-        r = self.get(player_receiver_endpoint)
-        messagequeue_url_template = r.json()["messagequeue_url"]
-        messagequeue_url_template = urllib.parse.unquote(messagequeue_url_template)
-        messages_url = r.json()["messages_url"]
+        player_receiver_endpoint, receiver_headers = self.make_player_message_endpoint_and_session()
+        messagequeue_url_template, messages_url = self.get_messages_url(player_receiver_endpoint)
 
         # send a message from another player
         player_sender = self.make_player()
@@ -89,48 +84,45 @@ class MessagesTest(BaseCloudkitTest):
         othermessagequeue_url = messagequeue_url_template.format(queue=otherqueue)
         otherdata = {"message": {"Hello": "OtherWorld"}}
 
-        r = self.post(messagequeue_url, data=data)
-        r = self.post(othermessagequeue_url, data=otherdata)
-        r = self.post(messagequeue_url, data=data)
-        r = self.post(othermessagequeue_url, data=otherdata)
-
-        top_message_number = r.json()["message_number"]
+        r = self.post(messagequeue_url, data=data, expected_status_code=http.client.OK)
+        first_message_id = r.json()["message_id"]
+        r = self.post(othermessagequeue_url, data=otherdata, expected_status_code=http.client.OK)
+        second_message_id = r.json()["message_id"]
+        r = self.post(messagequeue_url, data=data, expected_status_code=http.client.OK)
+        third_message_id = r.json()["message_id"]
+        r = self.post(othermessagequeue_url, data=otherdata, expected_status_code=http.client.OK)
+        last_message_id = r.json()["message_id"]
 
         # switch to the receiver player
         self.headers = receiver_headers
 
         # get all messages
-        print(messages_url)
         r = self.get(messages_url)
         js = r.json()
         self.assertEqual(len(js), 2)
         self.assertEqual(len(js[queue]), 2)
         self.assertEqual(len(js[otherqueue]), 2)
 
-        # get 1 row and verify that it is the latest one
+        # get 1 row and verify that it is the last one
         r = self.get(messages_url + "?rows=1")
         js = r.json()
         self.assertEqual(len(js), 1)
         self.assertNotIn(queue, js)
         self.assertEqual(len(js[otherqueue]), 1)
-        self.assertEqual(js[otherqueue][0]["message_number"], top_message_number)
+        self.assertEqual(js[otherqueue][0]["message_id"], last_message_id)
 
-        # get 2 rows and verify that we have one from each queue
+        # get 2 rows and verify that we have one from each queue from the end
         r = self.get(messages_url + "?rows=2")
         js = r.json()
         self.assertEqual(len(js), 2)
         self.assertEqual(len(js[queue]), 1)
+        self.assertEqual(js[queue][0]["message_id"], third_message_id)
         self.assertEqual(len(js[otherqueue]), 1)
+        self.assertEqual(js[otherqueue][0]["message_id"], last_message_id)
 
     def test_messages_after(self):
-        player_receiver = self.make_player()
-        receiver_headers = self.headers
-
-        player_receiver_endpoint = self.endpoints["my_player"]
-        r = self.get(player_receiver_endpoint)
-        messagequeue_url_template = r.json()["messagequeue_url"]
-        messagequeue_url_template = urllib.parse.unquote(messagequeue_url_template)
-        messages_url = r.json()["messages_url"]
+        player_receiver_endpoint, receiver_headers = self.make_player_message_endpoint_and_session()
+        messagequeue_url_template, messages_url = self.get_messages_url(player_receiver_endpoint)
 
         # send a message from another player
         player_sender = self.make_player()
@@ -140,37 +132,35 @@ class MessagesTest(BaseCloudkitTest):
         otherqueue = "othertestqueue"
         othermessagequeue_url = messagequeue_url_template.format(queue=otherqueue)
         otherdata = {"message": {"Hello": "OtherWorld"}}
-        r = self.post(messagequeue_url, data=data)
-        r = self.post(othermessagequeue_url, data=otherdata)
-        r = self.post(messagequeue_url, data=data)
-        r = self.post(othermessagequeue_url, data=otherdata)
-
-        top_message_number = int(r.json()["message_number"])
-        top_message_id = r.json()["message_id"]
+        r = self.post(messagequeue_url, data=data, expected_status_code=http.client.OK)
+        r = self.post(othermessagequeue_url, data=otherdata, expected_status_code=http.client.OK)
+        r = self.post(messagequeue_url, data=data, expected_status_code=http.client.OK)
+        before_end_message_id = r.json()["message_id"]
+        r = self.post(othermessagequeue_url, data=otherdata, expected_status_code=http.client.OK)
+        last_message_id = r.json()["message_id"]
 
         # switch to the receiver player
         self.headers = receiver_headers
 
         # get only the top row and verify that it is correct, each time
         for i in range(0, 2):
-            r = self.get(messages_url + "?messages_after=%s" % (top_message_number - 1))
+            r = self.get(messages_url + "?messages_after=%s" % before_end_message_id)
             js = r.json()
             # Check we got one queue
             self.assertEqual(len(js), 1)
             # Check we got one message in the queue
             self.assertEqual(len(js[otherqueue]), 1)
             record = js[otherqueue][0]
-            self.assertEqual(record["message_number"], top_message_number)
-            self.assertEqual(record["message_id"], top_message_id)
+            self.assertEqual(record["message_id"], last_message_id)
             self.assertEqual(record["payload"], otherdata["message"])
 
         # if we get by a larger number we should get nothing
-        r = self.get(messages_url + "?messages_after=%s" % (top_message_number))
+        r = self.get(messages_url + "?messages_after=%s" % last_message_id)
         js = r.json()
         self.assertEqual(js, {})
 
         # if we get by zero we should get nothing, as we've previously acknowledged a valid top number
-        r = self.get(messages_url + "?messages_after=%s" % (0))
+        r = self.get(messages_url + "?messages_after=%s" % '0')
         js = r.json()
         self.assertEqual(js, {})
 
@@ -183,10 +173,9 @@ class MessagesTest(BaseCloudkitTest):
         player_sender = self.make_player()
 
         # Post additional messages
-        r = self.post(othermessagequeue_url, data=otherdata)
-        r = self.post(othermessagequeue_url, data=otherdata)
-
-        top_message_number = int(r.json()["message_number"])
+        r = self.post(othermessagequeue_url, data=otherdata, expected_status_code=http.client.OK)
+        before_end_message_id = r.json()["message_id"]
+        r = self.post(othermessagequeue_url, data=otherdata, expected_status_code=http.client.OK)
         top_message_id = r.json()["message_id"]
 
         # switch to the receiver player
@@ -198,18 +187,12 @@ class MessagesTest(BaseCloudkitTest):
         self.assertEqual(len(js), 1)
         self.assertEqual(len(js[otherqueue]), 2)
         # Messages are returned newest first
-        self.assertEqual(js[otherqueue][0]["message_number"], top_message_number)
         self.assertEqual(js[otherqueue][0]["message_id"], top_message_id)
-        self.assertEqual(js[otherqueue][1]["message_number"], top_message_number - 1)
+        self.assertEqual(js[otherqueue][1]["message_id"], before_end_message_id)
 
     def test_messages_multiplequeues(self):
-        player_receiver = self.make_player()
-        receiver_headers = self.headers
-        player_receiver_endpoint = self.endpoints["my_player"]
-        r = self.get(player_receiver_endpoint)
-        messagequeue_url_template = r.json()["messagequeue_url"]
-        messagequeue_url_template = urllib.parse.unquote(messagequeue_url_template)
-        messages_url = r.json()["messages_url"]
+        player_receiver_endpoint, receiver_headers = self.make_player_message_endpoint_and_session()
+        messagequeue_url_template, messages_url = self.get_messages_url(player_receiver_endpoint)
 
         player_sender = self.make_player()
         num_queues = 5
@@ -218,36 +201,27 @@ class MessagesTest(BaseCloudkitTest):
             messagequeue_url = messagequeue_url_template.format(queue="testqueue-%s" % i)
             for j in range(num_messages_per_queue):
                 data = {"message": {"Hello": "World", "queuenumber": i, "messagenumber": j}}
-                r = self.post(messagequeue_url, data=data)
-                self.assertIn("payload", r.json())
-                self.assertEqual(r.json()["payload"]["queuenumber"], i)
-                self.assertEqual(r.json()["payload"]["messagenumber"], j)
+                r = self.post(messagequeue_url, data=data, expected_status_code=http.client.OK)
 
         # switch to the receiver player
         self.headers = receiver_headers
 
         # get all the queues and delete them
-        r = self.get(messages_url)
+        r = self.get(messages_url).json()
 
-        self.assertEqual(len(r.json()), num_queues)
-        for queue, messages in r.json().items():
+        self.assertEqual(len(r), num_queues)
+        for queue, messages in r.items():
             self.assertEqual(len(messages), num_messages_per_queue)
 
     def test_messages_longpoll(self):
-        player_receiver = self.make_player()
-        receiver_headers = self.headers
-
-        player_receiver_endpoint = self.endpoints["my_player"]
-        r = self.get(player_receiver_endpoint)
-        messagequeue_url_template = r.json()["messagequeue_url"]
-        messagequeue_url_template = urllib.parse.unquote(messagequeue_url_template)
-        messages_url = r.json()["messages_url"]
+        player_receiver_endpoint, receiver_headers = self.make_player_message_endpoint_and_session()
+        messagequeue_url_template, messages_url = self.get_messages_url(player_receiver_endpoint)
 
         # send a message from another player
         player_sender = self.make_player()
         messagequeue_url = messagequeue_url_template.format(queue="testqueue")
         data = {"message": {"Hello": "World"}}
-        r = self.post(messagequeue_url, data=data)
+        r = self.post(messagequeue_url, data=data, expected_status_code=http.client.OK)
         message_url = r.json()["url"]
 
         # switch to the receiver player

--- a/driftbase/tests/test_messages.py
+++ b/driftbase/tests/test_messages.py
@@ -70,13 +70,6 @@ class MessagesTest(BaseCloudkitTest):
         # get all the messages for the player again and make sure we're receiving the same thing
         self.assertEqual(self.get(messages_url).json(), r)
 
-        # get the messages and this time clear them as well
-        r = self.get(messages_url + "?delete=true").json()
-        self.assertIn("testqueue", r)
-        self.assertEqual(len(r["testqueue"]), 1)
-        self.assertIn("payload", r["testqueue"][0])
-        self.assertIn("Hello", r["testqueue"][0]["payload"])
-
     def test_messages_rows(self):
         player_receiver = self.make_player()
         receiver_headers = self.headers


### PR DESCRIPTION
This PR re-implements the message queue using Redis streams which simplifies queries and look-ups into each queue. It does away with the key and queue expiration settings that have caused problems in the old implementation.

It also creates a new REST API entry which is less verbose and which removes some oddities from the old one.

Clients may use either API and will get the same messages either way.

We can theoretically skip the new API and just use the new implementation, but there are some notable improvements in the new API which makes it worth keeping, IMO.