### PR TITLE
Fix field types of message properties

### DIFF
--- a/driftbase/api/messages.py
+++ b/driftbase/api/messages.py
@@ -42,6 +42,8 @@ def _patch_messages(messages):
     for k, v in iter(messages.items()):
         for e in v:
             e.update({'message_number': int(e['message_id'])})
+            e.update({'exchange_id': int(e['exchange_id'])})
+            e.update({'sender_id': int(e['sender_id'])})
         v.sort(key=operator.itemgetter("message_number"), reverse=True)
         patched[k] = v
     return patched

--- a/driftbase/api/messages.py
+++ b/driftbase/api/messages.py
@@ -11,7 +11,7 @@ import json
 import logging
 import marshmallow as ma
 import operator
-from flask import g, url_for, stream_with_context, Response, jsonify
+from flask import url_for, stream_with_context, Response, jsonify
 from flask.views import MethodView
 from flask_smorest import Blueprint, abort
 
@@ -41,9 +41,11 @@ def _patch_messages(messages):
     patched = {}
     for k, v in iter(messages.items()):
         for e in v:
-            e.update({'message_number': int(e['message_id'])})
-            e.update({'exchange_id': int(e['exchange_id'])})
-            e.update({'sender_id': int(e['sender_id'])})
+            e.update({
+                'message_number': int(e['message_id']),
+                'exchange_id': int(e['exchange_id']),
+                'sender_id': int(e['sender_id'])
+            })
         v.sort(key=operator.itemgetter("message_number"), reverse=True)
         patched[k] = v
     return patched

--- a/driftbase/tests/test_messages.py
+++ b/driftbase/tests/test_messages.py
@@ -63,13 +63,22 @@ class MessagesTest(BaseCloudkitTest):
         self.assertEqual(r["queue"], "testqueue")
         self.assertIn("payload", r)
         self.assertIn("Hello", r["payload"])
+        self.assertIsInstance(r["exchange_id"], int)
 
         # get all the messages for the player
         r = self.get(messages_url).json()
         self.assertIn("testqueue", r)
         self.assertEqual(len(r["testqueue"]), 1)
-        self.assertIn("payload", r["testqueue"][0])
-        self.assertIn("Hello", r["testqueue"][0]["payload"])
+        message = r["testqueue"][0]
+        self.assertIn("payload", message)
+        self.assertIn("Hello", message["payload"])
+        self.assertIsInstance(message["exchange"], str)
+        self.assertIsInstance(message["exchange_id"], int)
+        self.assertIsInstance(message["message_id"], str)
+        self.assertIsInstance(message["message_number"], int)
+        self.assertIsInstance(message["payload"], dict)
+        self.assertIsInstance(message["queue"], str)
+        self.assertIsInstance(message["sender_id"], int)
 
         # get all the messages for the player again and make sure we're receiving the same thing
         self.assertEqual(self.get(messages_url).json(), r)


### PR DESCRIPTION
Some types got lost when migrating the new implementation back to the old API