### PR TITLE
[counters] Optimize PUT/PATCH /players/<id>/counters

### DIFF
--- a/alembic/versions/1458e3a7775d_add_constraints_to_player_counters_and_.py
+++ b/alembic/versions/1458e3a7775d_add_constraints_to_player_counters_and_.py
@@ -1,0 +1,30 @@
+"""Add constraints to player counters and counter entries
+
+Revision ID: 1458e3a7775d
+Revises: ec5778e4aae1
+Create Date: 2021-09-19 14:20:01.627955
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = '1458e3a7775d'
+down_revision = 'ec5778e4aae1'
+branch_labels = None
+depends_on = None
+
+from alembic import op
+
+
+def upgrade(engine_name):
+    print("Upgrading {}".format(engine_name))
+    # TODO: Find violations in existing data and fix them
+    op.create_unique_constraint('ck_playercounters_counter_id_player_id_key', 'ck_playercounters',
+                                ['counter_id', 'player_id'])
+    op.create_unique_constraint('ck_counterentries_counter_id_player_id_period_date_time_key', 'ck_counterentries',
+                                ['counter_id', 'player_id', 'period', 'date_time'])
+
+
+def downgrade(engine_name):
+    print("Downgrading {}".format(engine_name))
+    op.drop_constraint('ck_counterentries_counter_id_player_id_period_date_time_key', 'ck_counterentries')
+    op.drop_constraint('ck_playercounters_counter_id_player_id_key', 'ck_playercounters')

--- a/alembic/versions/3b4283dcb935_migrate_counter_ids_to_bigint.py
+++ b/alembic/versions/3b4283dcb935_migrate_counter_ids_to_bigint.py
@@ -1,0 +1,28 @@
+"""Migrate counter ids to BigInt
+
+Revision ID: 3b4283dcb935
+Revises: 1458e3a7775d
+Create Date: 2021-09-19 22:59:57.965743
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = '3b4283dcb935'
+down_revision = '1458e3a7775d'
+branch_labels = None
+depends_on = None
+
+import sqlalchemy as sa
+from alembic import op
+
+
+def upgrade(engine_name):
+    print("Upgrading {}".format(engine_name))
+    op.alter_column('ck_playercounters', 'id', type_=sa.BigInteger)
+    op.alter_column('ck_counterentries', 'id', type_=sa.BigInteger)
+
+
+def downgrade(engine_name):
+    print("Downgrading {}".format(engine_name))
+    op.alter_column('ck_counterentries', 'id', type_=sa.Integer)
+    op.alter_column('ck_playercounters', 'id', type_=sa.Integer)

--- a/driftbase/api/players/counters.py
+++ b/driftbase/api/players/counters.py
@@ -210,8 +210,8 @@ class CountersApi(MethodView):
 
         batch_update_counter_entries(player_id, counter_updates)
 
-        for update in counters:
-            result[update["name"]] = "OK"
+        for name in counter_updates.keys():
+            result[name] = "OK"
 
         log.info("patch(%s) done in %.2fs!", player_id, time.time() - start_time)
         return jsonify(result)

--- a/driftbase/api/players/counters.py
+++ b/driftbase/api/players/counters.py
@@ -202,7 +202,7 @@ class CountersApi(MethodView):
         counter_ids = []
         counters = batch_get_or_create_counters([(k, v["counter_type"]) for k, v in counter_updates.items()])
         for (counter_id, name) in counters:
-            counter_updates[name].update(dict(counter_id=counter_id))
+            counter_updates[name]["counter_id"] = counter_id
             counter_ids.append(counter_id)
 
         # Player counters keep track of which counters have ever been set for a given player

--- a/driftbase/counters.py
+++ b/driftbase/counters.py
@@ -110,7 +110,6 @@ def batch_update_counter_entries(player_id, entries, db_session=None):
             index_elements=['counter_id', 'player_id', 'period', 'date_time'],
             set_=dict(value=insert_clause.excluded.value))
         db_session.execute(update_clause)
-        db_session.commit()
 
     if len(counter_values):
         insert_clause = insert(CounterEntry).values(counter_values)
@@ -118,7 +117,8 @@ def batch_update_counter_entries(player_id, entries, db_session=None):
             index_elements=['counter_id', 'player_id', 'period', 'date_time'],
             set_=dict(value=CounterEntry.value + insert_clause.excluded.value))
         db_session.execute(update_clause)
-        db_session.commit()
+
+    db_session.commit()
 
 
 def get_date_time_for_period(period, timestamp):

--- a/driftbase/counters.py
+++ b/driftbase/counters.py
@@ -65,17 +65,23 @@ def get_player(player_id):
 
 
 def batch_get_or_create_counter_ids(counters, db_session=None):
+    """
+    return [(counter_id, name), ...]
+    """
     if not db_session:
         db_session = g.db
 
     values = [{"name": name, "counter_type": counter_type} for (name, counter_type) in counters]
-    stm = insert(Counter).returning(Counter.counter_id, Counter.name, Counter.counter_type).values(values)
+    stm = insert(Counter).returning(Counter.counter_id, Counter.name).values(values)
     stm2 = stm.on_conflict_do_update(index_elements=['name'], set_=dict(name=stm.excluded.name))
     result = db_session.execute(stm2)
     return result
 
 
 def batch_get_or_create_player_counters(player_id, counter_ids, db_session=None):
+    """
+    return [(id, counter_id, last_update)]
+    """
     if not db_session:
         db_session = g.db
 

--- a/driftbase/models/db.py
+++ b/driftbase/models/db.py
@@ -1,7 +1,7 @@
 import datetime
 
 from drift.orm import ModelBase, utc_now, Base
-from sqlalchemy import CheckConstraint
+from sqlalchemy import CheckConstraint, UniqueConstraint
 from sqlalchemy import (
     Column,
     Integer,
@@ -228,6 +228,8 @@ class PlayerCounter(ModelBase):
     num_updates = Column(Integer, nullable=False, default=1)
     last_update = Column(DateTime, nullable=True)
 
+    UniqueConstraint(counter_id, player_id)
+
 
 class CounterEntry(Base):
     __tablename__ = "ck_counterentries"
@@ -254,6 +256,8 @@ class CounterEntry(Base):
     date_time = Column(DateTime, nullable=False, index=True, server_default=utc_now)
     value = Column(Float, nullable=False)
     context_id = Column(Integer, nullable=True, index=True)
+
+    UniqueConstraint(counter_id, player_id, period, date_time)
 
 
 # GameServer models

--- a/driftbase/models/db.py
+++ b/driftbase/models/db.py
@@ -218,7 +218,7 @@ class Counter(ModelBase):
 class PlayerCounter(ModelBase):
     __tablename__ = "ck_playercounters"
 
-    id = Column(Integer, primary_key=True)
+    id = Column(BigInteger, primary_key=True)
     counter_id = Column(
         Integer, ForeignKey("ck_counters.counter_id"), nullable=False, index=True
     )
@@ -234,7 +234,7 @@ class PlayerCounter(ModelBase):
 class CounterEntry(Base):
     __tablename__ = "ck_counterentries"
 
-    id = Column(Integer, primary_key=True)
+    id = Column(BigInteger, primary_key=True)
     counter_id = Column(
         Integer, ForeignKey("ck_counters.counter_id"), nullable=False, index=True
     )

--- a/driftbase/tests/players/test_counters.py
+++ b/driftbase/tests/players/test_counters.py
@@ -225,3 +225,28 @@ class CountersTests(DriftBaseTestCase):
         self.assertEqual(len(r.json()), 2)
         self.assertEqual(r.json()[name], val + second_val + third_val)
         self.assertEqual(r.json()[absolute_name], absolute_val)
+
+        timestamp = datetime.datetime(2016, 1, 1, 10, 2, 4)
+        fourth_val = 89
+        fifth_val = 100
+        absolute_val = 123
+        absolute_name = "my_absolute_counter"
+        data = [{"name": name,
+                 "value": fourth_val,
+                 "timestamp": timestamp.isoformat(),
+                 "counter_type": "count"},
+                {"name": name,
+                 "value": fifth_val,
+                 "timestamp": timestamp.isoformat(),
+                 "counter_type": "count"},
+                {"name": absolute_name,
+                 "value": absolute_val,
+                 "timestamp": timestamp.isoformat(),
+                 "counter_type": "absolute"}]
+
+        r = self.patch(counter_url, data=data)
+
+        r = self.get(countertotals_url)
+        self.assertEqual(len(r.json()), 2)
+        self.assertEqual(r.json()[name], val + second_val + third_val + fourth_val + fifth_val)
+        self.assertEqual(r.json()[absolute_name], absolute_val)

--- a/driftbase/tests/players/test_counters.py
+++ b/driftbase/tests/players/test_counters.py
@@ -64,6 +64,7 @@ class CountersTests(DriftBaseTestCase):
         # Log on as a service and retry
         self.auth_service()
         r = self.patch(counter_url, data=data)
+        self.assertEqual("OK", r.json()["my_counter"])
 
     @unittest.skip("Disabled because we are now using the servertime for the timestamp and "
                    "will therefore never get duplicate timestamps.")
@@ -81,6 +82,7 @@ class CountersTests(DriftBaseTestCase):
                  "timestamp": timestamp.isoformat(),
                  "counter_type": "count"}]
         r = self.patch(counter_url, data=data)
+        self.assertEqual("OK", r.json()["my_counter"])
         r = self.get(counter_url)
 
         # verify that we have one value per period
@@ -106,6 +108,7 @@ class CountersTests(DriftBaseTestCase):
         timestamp += datetime.timedelta(days=1)
         data[0]["timestamp"] = timestamp.isoformat()
         r = self.patch(counter_url, data=data)
+        self.assertEqual("OK", r.json()["my_counter"])
 
         r = self.get(period_urls["minute"])
         self.assertEqual(len(r.json().values()), 2)
@@ -125,6 +128,7 @@ class CountersTests(DriftBaseTestCase):
                  "counter_type": "count",
                  "context_id": 666}]
         r = self.patch(counter_url, data=data)
+        self.assertEqual("OK", r.json()["my_counter"])
 
     def test_counters_absolute(self):
         self.auth(username=uuid_string())
@@ -139,6 +143,7 @@ class CountersTests(DriftBaseTestCase):
                  "timestamp": timestamp.isoformat(),
                  "counter_type": "absolute"}]
         r = self.patch(counter_url, data=data)
+        self.assertEqual("OK", r.json()["my_absolute_counter"])
 
         r = self.get(counter_url)
         period_urls = r.json()[0]["periods"]
@@ -153,6 +158,7 @@ class CountersTests(DriftBaseTestCase):
                  "timestamp": timestamp.isoformat(),
                  "counter_type": "absolute"}]
         r = self.patch(counter_url, data=data)
+        self.assertEqual("OK", r.json()["my_absolute_counter"])
 
         r = self.get(period_urls["total"])
         self.assertEqual(list(r.json().values())[0], val)
@@ -175,6 +181,7 @@ class CountersTests(DriftBaseTestCase):
                  "timestamp": timestamp.isoformat(),
                  "counter_type": "count"}]
         r = self.patch(counter_url, data=data)
+        self.assertEqual("OK", r.json()[name])
         r = self.get(countertotals_url)
 
         self.assertEqual(len(r.json()), 1)
@@ -197,6 +204,7 @@ class CountersTests(DriftBaseTestCase):
                  "timestamp": timestamp.isoformat(),
                  "counter_type": "count"}]
         r = self.patch(counter_url, data=data)
+        self.assertEqual("OK", r.json()[name])
 
         timestamp = datetime.datetime(2016, 1, 1, 10, 2, 3)
         second_val = 99
@@ -205,8 +213,8 @@ class CountersTests(DriftBaseTestCase):
                  "value": second_val,
                  "timestamp": timestamp.isoformat(),
                  "counter_type": "count"}]
-
         r = self.patch(counter_url, data=data)
+        self.assertEqual("OK", r.json()[name])
 
         timestamp = datetime.datetime(2016, 1, 1, 10, 2, 2)
         third_val = 42
@@ -220,8 +228,9 @@ class CountersTests(DriftBaseTestCase):
                  "value": absolute_val,
                  "timestamp": timestamp.isoformat(),
                  "counter_type": "absolute"}]
-
         r = self.patch(counter_url, data=data)
+        self.assertEqual("OK", r.json()[name])
+        self.assertEqual("OK", r.json()[absolute_name])
 
         r = self.get(countertotals_url)
         self.assertEqual(len(r.json()), 2)
@@ -245,8 +254,10 @@ class CountersTests(DriftBaseTestCase):
                  "value": absolute_val,
                  "timestamp": timestamp.isoformat(),
                  "counter_type": "absolute"}]
-
         r = self.patch(counter_url, data=data)
+        self.assertEqual("OK", r.json()[name])
+        self.assertEqual("OK", r.json()[absolute_name])
+        self.assertEqual(2, len(r.json().keys()))
 
         r = self.get(countertotals_url)
         self.assertEqual(len(r.json()), 2)

--- a/driftbase/tests/players/test_counters.py
+++ b/driftbase/tests/players/test_counters.py
@@ -30,6 +30,8 @@ class CountersTests(DriftBaseTestCase):
                  "timestamp": timestamp.isoformat(),
                  "counter_type": "count"}]
         r = self.patch(counter_url, data=data)
+        self.assertEqual("OK", r.json()["my_counter"])
+
         r = self.get(counter_url)
 
         # verify that we have one value per period

--- a/driftbase/tests/players/test_counters.py
+++ b/driftbase/tests/players/test_counters.py
@@ -180,7 +180,7 @@ class CountersTests(DriftBaseTestCase):
         self.assertEqual(r.json()[name], val)
 
     def test_counters_multiple(self):
-        # test writing to the same counter more than once. The total count should upgade
+        # test writing to the same counter more than once. The total count should upgrade
         self.auth(username=uuid_string())
         player_url = self.endpoints["my_player"]
         r = self.get(player_url)
@@ -207,9 +207,14 @@ class CountersTests(DriftBaseTestCase):
         r = self.patch(counter_url, data=data)
 
         timestamp = datetime.datetime(2016, 1, 1, 10, 2, 2)
+        third_val = 42
         absolute_val = 666
         absolute_name = "my_absolute_counter"
-        data = [{"name": absolute_name,
+        data = [{"name": name,
+                 "value": third_val,
+                 "timestamp": timestamp.isoformat(),
+                 "counter_type": "count"},
+                {"name": absolute_name,
                  "value": absolute_val,
                  "timestamp": timestamp.isoformat(),
                  "counter_type": "absolute"}]
@@ -218,5 +223,5 @@ class CountersTests(DriftBaseTestCase):
 
         r = self.get(countertotals_url)
         self.assertEqual(len(r.json()), 2)
-        self.assertEqual(r.json()[name], val + second_val)
+        self.assertEqual(r.json()[name], val + second_val + third_val)
         self.assertEqual(r.json()[absolute_name], absolute_val)


### PR DESCRIPTION
- Batch generate counters, instead of running redis/query/create for each one
- Batch generate player counters, instead of running query/create for each one
- Batch update counter entries, instead of running insert for each set of periods
- Relies on custom postgresql features, ON CONFLICT and RETURNING
  to efficiently UPSERT multiple columns while returning the final
  values in a non-complex statement. Essentially, all queries now take the form of:
```
INSERT INTO table (col1, ..., colN) VALUES (v1a, ..., vNa), (v1P, ..., vNP)
ON CONFLICT (col1, ..., colN) DO UPDATE SET <expression>;
``` 
- Migrate PlayerCounter and CounterEntry primary keys to BigInt
- Ensure uniqueness of PlayerCounter and CounterEntry rows