### PR TITLE
Bugfix/counter create deadlock

### DIFF
--- a/driftbase/counters.py
+++ b/driftbase/counters.py
@@ -4,6 +4,7 @@ import logging
 import six
 from flask import g
 from sqlalchemy.dialects.postgresql import insert
+from sqlalchemy.exc import OperationalError
 
 from driftbase.models.db import Counter, CorePlayer, PlayerCounter, CounterEntry
 
@@ -11,6 +12,8 @@ COUNTER_CACHE_TTL = 60 * 10
 
 TOTAL_TIMESTAMP = datetime.datetime.strptime("2000-01-01", "%Y-%m-%d")
 COUNTER_PERIODS = ['total', 'month', 'day', 'hour', 'minute', 'second']
+
+MAX_RETRIES = 3
 
 log = logging.getLogger(__name__)
 
@@ -72,12 +75,16 @@ def batch_get_or_create_counters(counters, db_session=None):
     # https://dba.stackexchange.com/questions/194756/deadlock-with-multi-row-inserts-despite-on-conflict-do-nothing/195220#195220
     counters.sort(key=lambda x: x[0])
     values = [{"name": name, "counter_type": counter_type} for (name, counter_type) in counters]
-    insert_clause = insert(Counter).returning(Counter.counter_id, Counter.name).values(values)
-    # This is essentially a no-op, but it's required to ensure we get all the IDs back in the result
-    update_clause = insert_clause.on_conflict_do_update(index_elements=['name'],
-                                                        set_=dict(name=insert_clause.excluded.name))
-    result = db_session.execute(update_clause)
-    return result
+    for retry in range(0, MAX_RETRIES):
+        try:
+            insert_clause = insert(Counter).returning(Counter.counter_id, Counter.name).values(values)
+            # This is essentially a no-op, but it's required to ensure we get all the IDs back in the result
+            update_clause = insert_clause.on_conflict_do_update(index_elements=['name'],
+                                                                set_=dict(name=insert_clause.excluded.name))
+            result = db_session.execute(update_clause)
+            return result
+        except OperationalError:
+            log.info(f"Failed to upsert counters due to concurrency conflicts, retrying {retry + 1}/{MAX_RETRIES}...")
 
 
 def batch_create_player_counters(player_id, counter_ids, db_session=None):


### PR DESCRIPTION
When we're adding new counter names, the upsert logic can cause a deadlock, making at least one of the updates fail.

The recommendation on the internet is to sort the values to prevent AB/BA locks, but it's not very well described exactly what happens.

Additionally, we retry the call if it fails, to avoid losing any counters, and to get notified in the log