### PR TITLE
Normalize URLs with dashes instead of underscores

### DIFF
--- a/driftbase/api/matchmakers/flexmatch.py
+++ b/driftbase/api/matchmakers/flexmatch.py
@@ -194,7 +194,7 @@ class FlexMatchEventAPI(MethodView):
         flexmatch.process_flexmatch_event(request.json)
         return {}, http_client.OK
 
-@bp.route("/queue_events", endpoint="queue_events")
+@bp.route("/queue-events", endpoint="queue_events")
 class FlexMatchQueueEventAPI(MethodView):
 
     @requires_roles("flexmatch_event")

--- a/driftbase/api/parties.py
+++ b/driftbase/api/parties.py
@@ -17,7 +17,7 @@ from driftbase.parties import accept_party_invite, get_player_party, get_party_m
 log = logging.getLogger(__name__)
 
 bp_parties = Blueprint("parties", __name__, url_prefix='/parties')
-bp_party_invites = Blueprint("party_invites", __name__, url_prefix='/party_invites')
+bp_party_invites = Blueprint("party_invites", __name__, url_prefix='/party-invites')
 endpoints = Endpoints()
 
 


### PR DESCRIPTION
All previous URLs are built using dashes, never underscores. Underscores are used for the JSON property names to ensure they can be serialized into a struct in most languages, where dash is not a valid identifier character.