### PR TITLE
Update friend presence

### DIFF
--- a/driftbase/api/clients.py
+++ b/driftbase/api/clients.py
@@ -226,11 +226,6 @@ class ClientsAPI(MethodView):
             "jwt": jwt,
         }
 
-        current_app.extensions['messagebus'].publish_message(
-            'clients',
-            {'event': 'created', 'payload': payload, 'url': resource_url}
-        )
-
         return ret
 
 
@@ -329,6 +324,14 @@ class ClientAPI(MethodView):
 
         log.info("Client %s from player %s has been unregistered",
                  client_id, current_user["player_id"])
+
+        message_data = {
+            "event": "deleted",
+            "player_id": current_user["player_id"],
+            "client_id": client_id,
+        }
+
+        current_app.extensions["messagebus"].publish_message("client", message_data)
 
         return json_response("Client has been closed. Please terminate the client.",
                              http_client.OK)


### PR DESCRIPTION
We would like to somehow update the presence of players' friends when they go online/offline.

Initial implementation:

- Update online
	1. Client registers itself with Drift
	2. Client later makes a `friends` playergroup which includes all the player ids
	3. Hook into the event when the playergroup is created
	4. Fetch all players in the created `friends` playergroup from db that have a registered active, non-heartbeat-timeout client
	5. Post message to those players that the player has come online

- Update offline
	1. Client deregisters
	2. Hook into the event when the client is deregistered
	3. Fetch the `friends` playergroup for the exiting player
	4. Same as above, fetch the players in the group with same criteria
	5. Post offline message to those players

Issues:
- Whenever the client calls `LoadDriftFriends` the `friends` playergroup is created/updated/set and fires the event online event/message again
	- Receiving clients can deduce whether or not to broadcast the `OnFriendsPresenceChanged` delegate by comparing their locally cached state and see if the presence really changed
	- Can also be solved via using the friend messaging system
		- When a player comes online and has populated his local friends list, send the online message to players in the local friends list
- Doesn't handle ungraceful exits (crash, d/c, etc...)
	- One idea is to utilize the client heartbeat
		- When a client heartbeats, fetch all the player's online friends and check their client heartbeat timeout
		- Not sure of the performance impact this might have