### PR TITLE
Add support for Epic Online Services auth

### DIFF
--- a/driftbase/auth/__init__.py
+++ b/driftbase/auth/__init__.py
@@ -12,6 +12,7 @@ AUTH_MODULES = {
     'psn': 'driftbase.auth.psn',
     'steam': 'driftbase.auth.steam',
     'epic': 'driftbase.auth.epic',
+    'eos': 'driftbase.auth.eos',
 }
 
 LOCAL_AUTH = [

--- a/driftbase/auth/eos.py
+++ b/driftbase/auth/eos.py
@@ -1,0 +1,144 @@
+from json import JSONDecodeError
+
+import http.client as http_client
+import jwt
+import logging
+import marshmallow as ma
+from datetime import timedelta
+from flask_smorest import abort
+from jwt import PyJWKClientError
+from urllib.error import URLError
+from werkzeug.security import pbkdf2_hex
+
+from driftbase.auth import get_provider_config
+from .authenticate import authenticate as base_authenticate, AuthenticationException, ServiceUnavailableException, \
+    abort_unauthorized, InvalidRequestException, UnauthorizedException
+
+EPIC_PUBLIC_KEYS_URL = "https://api.epicgames.dev/epic/oauth/v1/.well-known/jwks.json"
+TRUSTED_ISSUER_URL_BASE = 'https://api.epicgames.dev/'
+
+JWT_ALGORITHM = "RS256"
+JWT_LEEWAY = 10
+JWT_VERIFY_CLAIMS = ["signature", "exp", "iat"]
+JWT_REQUIRED_CLAIMS = ["exp", "iat", "sub"]
+
+log = logging.getLogger(__name__)
+
+
+class EOSProviderAuthDetailsSchema(ma.Schema):
+    token = ma.fields.String(required=True, allow_none=False)
+
+
+def authenticate(auth_info):
+    assert auth_info['provider'] == 'eos'
+
+    try:
+        parameters = load_provider_details(auth_info['provider_details'])
+    except InvalidRequestException as e:
+        abort(http_client.BAD_REQUEST, message=e.msg)
+    except KeyError as e:
+        abort(http_client.BAD_REQUEST, message="Missing provider_details")
+    else:
+        try:
+            identity_id = validate_eos_token(**parameters)
+        except ServiceUnavailableException as e:
+            abort(http_client.SERVICE_UNAVAILABLE, message=e.msg)
+        except InvalidRequestException as e:
+            abort(http_client.BAD_REQUEST, message=e.msg)
+        except AuthenticationException as e:
+            abort_unauthorized(e.msg)
+        else:
+            automatic_account_creation = auth_info.get('automatic_account_creation', True)
+            # FIXME: The static salt should perhaps be configured per tenant
+            username = "eos:" + pbkdf2_hex(identity_id, 'static_salt', iterations=1)
+            return base_authenticate(username, "", automatic_account_creation)
+
+
+def load_provider_details(provider_details):
+    try:
+        details = EOSProviderAuthDetailsSchema().load(provider_details)
+    except ma.exceptions.ValidationError as e:
+        raise InvalidRequestException(f"{e}") from None
+    else:
+        return details
+
+
+def validate_eos_token(token):
+    """Validates an Epic Online Services OpenID token.
+
+    Returns the Epic Account ID for this player.
+
+    The audience claim must match one of the configured client_ids for the product.
+
+    Example:
+
+    provider_details = {
+        "token": "ZuhbO8TqGKadYAZHsDd5NgTs/tmM8sIqhtxuUmxOlhmp8PUAofIYzdwaN..."
+    }
+
+    validate_eos_token(provider_details)
+    """
+
+    eos_config = get_provider_config('eos')
+    if not eos_config:
+        raise ServiceUnavailableException("Epic Online Services authentication not configured for current tenant")
+
+    return run_eos_token_validation(token, eos_config.get('client_ids'))
+
+
+def run_eos_token_validation(token, client_ids):
+    public_key = _get_public_key(token)
+    payload = _decode_and_verify_jwt(token, public_key, client_ids)
+
+    return payload["sub"]
+
+
+def _decode_and_verify_jwt(token, key, audience):
+    options = {
+        'verify_' + claim: True
+        for claim in JWT_VERIFY_CLAIMS
+    }
+
+    options.update({
+        'require_' + claim: True
+        for claim in JWT_REQUIRED_CLAIMS
+    })
+
+    try:
+        payload = jwt.decode(
+            jwt=token,
+            key=key,
+            options=options,
+            audience=audience,
+            algorithms=[JWT_ALGORITHM],
+            leeway=timedelta(seconds=JWT_LEEWAY)
+        )
+    except jwt.MissingRequiredClaimError as e:
+        raise UnauthorizedException(f"Invalid token: {str(e)}")
+    except jwt.InvalidTokenError as e:
+        raise UnauthorizedException(f"Invalid token: {str(e)}")
+    else:
+        # EOS docs says to verify only the prefix, not the entire issuer string,
+        # so we have to verify it manually.
+        # See https://dev.epicgames.com/docs/services/en-US/EpicAccountServices/AuthInterface/index.html#validatingidtokensonbackendwithoutsdk
+        issuer = payload.get("iss")
+        if not issuer:
+            raise UnauthorizedException("Invalid JWT, no issuer found")
+        if not issuer.startswith(TRUSTED_ISSUER_URL_BASE):
+            raise UnauthorizedException("Invalid JWT, issuer not trusted")
+
+        return payload
+
+
+def _get_public_key(token):
+    try:
+        jwk_client = jwt.PyJWKClient(EPIC_PUBLIC_KEYS_URL)
+        jwk = jwk_client.get_signing_key_from_jwt(token)
+    except URLError as e:
+        raise ServiceUnavailableException("Failed to fetch public keys for token validation") from e
+    except (JSONDecodeError, PyJWKClientError) as e:
+        raise ServiceUnavailableException("Failed to read public keys for token validation") from None
+    else:
+        if jwk is None:
+            raise UnauthorizedException("Failed to find a matching public key for token validation")
+        return jwk.key

--- a/driftbase/tests/auth/test_eos.py
+++ b/driftbase/tests/auth/test_eos.py
@@ -5,7 +5,7 @@ import jwt
 import unittest
 
 import driftbase.auth.eos as eos
-from driftbase.auth.authenticate import InvalidRequestException, AuthenticationException, ServiceUnavailableException, \
+from driftbase.auth.authenticate import InvalidRequestException, ServiceUnavailableException, \
     UnauthorizedException
 
 # Examples from https://tools.ietf.org/html/rfc7518, https://tools.ietf.org/html/rfc7519
@@ -16,6 +16,7 @@ TEST_JWK_SET = '''{
         {"kty":"oct", "k":"AyM1SysPpbyDfgZld3umj1qzKObwVMkoqQ-EstJQLr_T-1qS0gZH75aKtMN3Yj0iPS4hcgUuTwjAzZr1Z9CAow", "kid":"test"}
     ]
 }'''
+TEST_JWT_ALGORITHM = 'HS256'
 
 
 class TestEosAuthenticate(unittest.TestCase):
@@ -31,16 +32,16 @@ class TestEosAuthenticate(unittest.TestCase):
 class TestEosLoadProviderDetails(unittest.TestCase):
     def test_fails_if_provider_details_missing_or_wrong_type(self):
         with self.assertRaises(InvalidRequestException):
-            eos.load_provider_details(dict(token=None))
+            eos._load_provider_details(dict(token=None))
         with self.assertRaises(InvalidRequestException):
-            eos.load_provider_details(dict(token=34))
+            eos._load_provider_details(dict(token=34))
         with self.assertRaises(InvalidRequestException):
-            eos.load_provider_details(dict(token=[]))
+            eos._load_provider_details(dict(token=[]))
         with self.assertRaises(InvalidRequestException):
-            eos.load_provider_details(dict(token='abc', other=3))
+            eos._load_provider_details(dict(token='abc', other=3))
 
     def test_loads_provider_details(self):
-        details = eos.load_provider_details(dict(token='abc'))
+        details = eos._load_provider_details(dict(token='abc'))
         self.assertEqual(details['token'], 'abc')
 
 
@@ -49,24 +50,23 @@ class TestEosValidate(unittest.TestCase):
         with mock.patch('driftbase.auth.eos.get_provider_config') as config:
             config.return_value = None
             with self.assertRaises(ServiceUnavailableException):
-                eos.validate_eos_token('abc')
+                eos._validate_eos_token('abc')
 
     def test_passes_configuration_to_implementation(self):
         with mock.patch('driftbase.auth.eos.get_provider_config') as config:
             config.return_value = dict(client_ids=['xyz'])
-            with mock.patch('driftbase.auth.eos.run_eos_token_validation') as validation:
+            with mock.patch('driftbase.auth.eos._run_eos_token_validation') as validation:
                 validation.return_value = 0
-                eos.validate_eos_token('abc')
+                eos._validate_eos_token('abc')
                 validation.assert_called_once_with('abc', ['xyz'])
 
 
-@mock.patch('driftbase.auth.eos.JWT_ALGORITHM', 'HS256')
-class TestEosRunAuthentication(unittest.TestCase):
+class TestEosGetKeys(unittest.TestCase):
     @mock.patch('driftbase.auth.eos.EPIC_PUBLIC_KEYS_URL', 'https://invalid.com/index.html')
     def test_fails_when_failing_to_load_keys(self):
-        with self.assertRaises(AuthenticationException) as e:
-            eos.run_eos_token_validation(TEST_JWT, [])
-        self.assertTrue(e.exception.msg.find('fetch') != -1)
+        with self.assertRaises(ServiceUnavailableException) as e:
+            eos._get_key_from_token(TEST_JWT)
+        self.assertTrue(e.exception.msg.find('Failed to fetch') != -1)
 
     def test_fails_when_key_set_is_empty(self):
         with mock.patch('driftbase.auth.eos.jwt.PyJWKClient') as mock_jwk_client:
@@ -74,61 +74,73 @@ class TestEosRunAuthentication(unittest.TestCase):
             instance.fetch_data.return_value = json.loads('{}')
             instance.get_signing_key_from_jwt.return_value = None
             with self.assertRaises(UnauthorizedException) as e:
-                eos.run_eos_token_validation(TEST_JWT, [])
+                eos._get_key_from_token(TEST_JWT)
             self.assertTrue(e.exception.msg.find('Failed to find') != -1)
 
     def test_fails_when_key_set_is_invalid(self):
         with mock.patch.object(eos.jwt.PyJWKClient, 'fetch_data') as mock_fetch:
             mock_fetch.side_effect = json.decoder.JSONDecodeError('mock', '', 42)
             with self.assertRaises(ServiceUnavailableException) as e:
-                eos.run_eos_token_validation(TEST_JWT, [])
+                eos._get_key_from_token(TEST_JWT)
             self.assertTrue(e.exception.msg.find('Failed to read') != -1)
 
+
+@mock.patch('driftbase.auth.eos.JWT_ALGORITHM', TEST_JWT_ALGORITHM)
+class TestEosRunAuthentication(unittest.TestCase):
+    def setUp(self):
+        self.token_audience = 'foo'
+        self.valid_client_ids = [self.token_audience]
+        self.expected_sub = 'eos_account_id'
+
     def test_decodes_and_validates_the_sub(self):
-        payload = dict(aud='foo', iss=eos.TRUSTED_ISSUER_URL_BASE, sub='abc')
+        payload = dict(aud=self.token_audience, iss=eos.TRUSTED_ISSUER_URL_BASE, sub=self.expected_sub)
         token, jwk = _make_test_token_and_key(payload)
-        with mock.patch('driftbase.auth.eos.jwt.PyJWKClient') as mock_jwk_client:
-            instance = mock_jwk_client.return_value
-            instance.get_signing_key_from_jwt.return_value = jwk
-            self.assertEqual(eos.run_eos_token_validation(token, ['foo']), 'abc')
+        with mock.patch('driftbase.auth.eos._get_key_from_token', return_value=jwk.key):
+            self.assertEqual(eos._run_eos_token_validation(token, self.valid_client_ids), self.expected_sub)
 
     def test_fails_when_audience_is_missing(self):
-        payload = dict(iss=eos.TRUSTED_ISSUER_URL_BASE, sub='abc')
+        payload = dict(iss=eos.TRUSTED_ISSUER_URL_BASE, sub=self.expected_sub)
         token, jwk = _make_test_token_and_key(payload)
-        with mock.patch('driftbase.auth.eos.jwt.PyJWKClient') as mock_jwk_client:
-            instance = mock_jwk_client.return_value
-            instance.get_signing_key_from_jwt.return_value = jwk
+        with mock.patch('driftbase.auth.eos._get_key_from_token', return_value=jwk.key):
             with self.assertRaises(UnauthorizedException):
-                eos.run_eos_token_validation(token, ['foo']), 'abc'
+                eos._run_eos_token_validation(token, self.valid_client_ids), self.expected_sub
 
     def test_fails_when_audience_is_wrong(self):
-        payload = dict(aud='bar', iss=eos.TRUSTED_ISSUER_URL_BASE, sub='abc')
+        payload = dict(aud='other', iss=eos.TRUSTED_ISSUER_URL_BASE, sub=self.expected_sub)
         token, jwk = _make_test_token_and_key(payload)
-        with mock.patch('driftbase.auth.eos.jwt.PyJWKClient') as mock_jwk_client:
-            instance = mock_jwk_client.return_value
-            instance.get_signing_key_from_jwt.return_value = jwk
+        with mock.patch('driftbase.auth.eos._get_key_from_token', return_value=jwk.key):
             with self.assertRaises(UnauthorizedException):
-                eos.run_eos_token_validation(token, ['foo']), 'abc'
+                eos._run_eos_token_validation(token, self.valid_client_ids), self.expected_sub
 
     def test_fails_when_issuer_is_missing(self):
-        payload = dict(aus='foo', sub='abc')
+        payload = dict(aus=self.token_audience, sub=self.expected_sub)
         token, jwk = _make_test_token_and_key(payload)
-        with mock.patch('driftbase.auth.eos.jwt.PyJWKClient') as mock_jwk_client:
-            instance = mock_jwk_client.return_value
-            instance.get_signing_key_from_jwt.return_value = jwk
+        with mock.patch('driftbase.auth.eos._get_key_from_token', return_value=jwk.key):
             with self.assertRaises(UnauthorizedException):
-                eos.run_eos_token_validation(token, ['foo']), 'abc'
+                eos._run_eos_token_validation(token, self.valid_client_ids), self.expected_sub
 
     def test_fails_when_issuer_is_wrong(self):
-        payload = dict(aus='foo', iss='Acme Industries', sub='abc')
+        payload = dict(aus=self.token_audience, iss='Acme Industries', sub=self.expected_sub)
         token, jwk = _make_test_token_and_key(payload)
-        with mock.patch('driftbase.auth.eos.jwt.PyJWKClient') as mock_jwk_client:
-            instance = mock_jwk_client.return_value
-            instance.get_signing_key_from_jwt.return_value = jwk
+        with mock.patch('driftbase.auth.eos._get_key_from_token', return_value=jwk.key):
             with self.assertRaises(UnauthorizedException):
-                eos.run_eos_token_validation(token, ['foo']), 'abc'
+                eos._run_eos_token_validation(token, self.valid_client_ids), self.expected_sub
+
+    def test_fails_when_keys_cannot_be_accessed(self):
+        payload = dict(aus=self.token_audience, iss=eos.TRUSTED_ISSUER_URL_BASE, sub=self.expected_sub)
+        token, jwk = _make_test_token_and_key(payload)
+        with mock.patch('driftbase.auth.eos._get_key_from_token', side_effect=ServiceUnavailableException("")):
+            with self.assertRaises(ServiceUnavailableException):
+                eos._run_eos_token_validation(token, self.valid_client_ids), self.expected_sub
+
+    def test_fails_when_key_cannot_be_found(self):
+        payload = dict(aus=self.token_audience, iss=eos.TRUSTED_ISSUER_URL_BASE, sub=self.expected_sub)
+        token, jwk = _make_test_token_and_key(payload)
+        with mock.patch('driftbase.auth.eos._get_key_from_token', side_effect=UnauthorizedException("")):
+            with self.assertRaises(UnauthorizedException):
+                eos._run_eos_token_validation(token, self.valid_client_ids), self.expected_sub
 
 
 def _make_test_token_and_key(payload):
     jwk = jwt.PyJWK.from_json(TEST_JWK)
-    return jwt.encode(payload=payload, key=jwk.key, algorithm='HS256'), jwk
+    return jwt.encode(payload=payload, key=jwk.key, algorithm=TEST_JWT_ALGORITHM), jwk

--- a/driftbase/tests/auth/test_eos.py
+++ b/driftbase/tests/auth/test_eos.py
@@ -1,0 +1,134 @@
+from unittest import mock
+
+import json
+import jwt
+import unittest
+
+import driftbase.auth.eos as eos
+from driftbase.auth.authenticate import InvalidRequestException, AuthenticationException, ServiceUnavailableException, \
+    UnauthorizedException
+
+# Examples from https://tools.ietf.org/html/rfc7518, https://tools.ietf.org/html/rfc7519
+TEST_JWT = 'eyJ0eXAiOiJKV1QiLA0KICJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJqb2UiLA0KICJleHAiOjEzMDA4MTkzODAsDQogImh0dHA6Ly9leGFtcGxlLmNvbS9pc19yb290Ijp0cnVlfQ.dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk'
+TEST_JWK = '{"kty":"oct", "k":"AyM1SysPpbyDfgZld3umj1qzKObwVMkoqQ-EstJQLr_T-1qS0gZH75aKtMN3Yj0iPS4hcgUuTwjAzZr1Z9CAow", "kid":"test"}'
+TEST_JWK_SET = '''{
+    "keys":[
+        {"kty":"oct", "k":"AyM1SysPpbyDfgZld3umj1qzKObwVMkoqQ-EstJQLr_T-1qS0gZH75aKtMN3Yj0iPS4hcgUuTwjAzZr1Z9CAow", "kid":"test"}
+    ]
+}'''
+
+
+class TestEosAuthenticate(unittest.TestCase):
+    def test_fails_if_missing_or_incorrect_provider_name(self):
+        with self.assertRaises(KeyError):
+            eos.authenticate(dict())
+        with self.assertRaises(AssertionError):
+            eos.authenticate(dict(provider=None))
+        with self.assertRaises(AssertionError):
+            eos.authenticate(dict(provider='myspace'))
+
+
+class TestEosLoadProviderDetails(unittest.TestCase):
+    def test_fails_if_provider_details_missing_or_wrong_type(self):
+        with self.assertRaises(InvalidRequestException):
+            eos.load_provider_details(dict(token=None))
+        with self.assertRaises(InvalidRequestException):
+            eos.load_provider_details(dict(token=34))
+        with self.assertRaises(InvalidRequestException):
+            eos.load_provider_details(dict(token=[]))
+        with self.assertRaises(InvalidRequestException):
+            eos.load_provider_details(dict(token='abc', other=3))
+
+    def test_loads_provider_details(self):
+        details = eos.load_provider_details(dict(token='abc'))
+        self.assertEqual(details['token'], 'abc')
+
+
+class TestEosValidate(unittest.TestCase):
+    def test_fails_without_configuration(self):
+        with mock.patch('driftbase.auth.eos.get_provider_config') as config:
+            config.return_value = None
+            with self.assertRaises(ServiceUnavailableException):
+                eos.validate_eos_token('abc')
+
+    def test_passes_configuration_to_implementation(self):
+        with mock.patch('driftbase.auth.eos.get_provider_config') as config:
+            config.return_value = dict(client_ids=['xyz'])
+            with mock.patch('driftbase.auth.eos.run_eos_token_validation') as validation:
+                validation.return_value = 0
+                eos.validate_eos_token('abc')
+                validation.assert_called_once_with('abc', ['xyz'])
+
+
+@mock.patch('driftbase.auth.eos.JWT_ALGORITHM', 'HS256')
+class TestEosRunAuthentication(unittest.TestCase):
+    @mock.patch('driftbase.auth.eos.EPIC_PUBLIC_KEYS_URL', 'https://invalid.com/index.html')
+    def test_fails_when_failing_to_load_keys(self):
+        with self.assertRaises(AuthenticationException) as e:
+            eos.run_eos_token_validation(TEST_JWT, [])
+        self.assertTrue(e.exception.msg.find('fetch') != -1)
+
+    def test_fails_when_key_set_is_empty(self):
+        with mock.patch('driftbase.auth.eos.jwt.PyJWKClient') as mock_jwk_client:
+            instance = mock_jwk_client.return_value
+            instance.fetch_data.return_value = json.loads('{}')
+            instance.get_signing_key_from_jwt.return_value = None
+            with self.assertRaises(UnauthorizedException) as e:
+                eos.run_eos_token_validation(TEST_JWT, [])
+            self.assertTrue(e.exception.msg.find('Failed to find') != -1)
+
+    def test_fails_when_key_set_is_invalid(self):
+        with mock.patch.object(eos.jwt.PyJWKClient, 'fetch_data') as mock_fetch:
+            mock_fetch.side_effect = json.decoder.JSONDecodeError('mock', '', 42)
+            with self.assertRaises(ServiceUnavailableException) as e:
+                eos.run_eos_token_validation(TEST_JWT, [])
+            self.assertTrue(e.exception.msg.find('Failed to read') != -1)
+
+    def test_decodes_and_validates_the_sub(self):
+        payload = dict(aud='foo', iss=eos.TRUSTED_ISSUER_URL_BASE, sub='abc')
+        token, jwk = _make_test_token_and_key(payload)
+        with mock.patch('driftbase.auth.eos.jwt.PyJWKClient') as mock_jwk_client:
+            instance = mock_jwk_client.return_value
+            instance.get_signing_key_from_jwt.return_value = jwk
+            self.assertEqual(eos.run_eos_token_validation(token, ['foo']), 'abc')
+
+    def test_fails_when_audience_is_missing(self):
+        payload = dict(iss=eos.TRUSTED_ISSUER_URL_BASE, sub='abc')
+        token, jwk = _make_test_token_and_key(payload)
+        with mock.patch('driftbase.auth.eos.jwt.PyJWKClient') as mock_jwk_client:
+            instance = mock_jwk_client.return_value
+            instance.get_signing_key_from_jwt.return_value = jwk
+            with self.assertRaises(UnauthorizedException):
+                eos.run_eos_token_validation(token, ['foo']), 'abc'
+
+    def test_fails_when_audience_is_wrong(self):
+        payload = dict(aud='bar', iss=eos.TRUSTED_ISSUER_URL_BASE, sub='abc')
+        token, jwk = _make_test_token_and_key(payload)
+        with mock.patch('driftbase.auth.eos.jwt.PyJWKClient') as mock_jwk_client:
+            instance = mock_jwk_client.return_value
+            instance.get_signing_key_from_jwt.return_value = jwk
+            with self.assertRaises(UnauthorizedException):
+                eos.run_eos_token_validation(token, ['foo']), 'abc'
+
+    def test_fails_when_issuer_is_missing(self):
+        payload = dict(aus='foo', sub='abc')
+        token, jwk = _make_test_token_and_key(payload)
+        with mock.patch('driftbase.auth.eos.jwt.PyJWKClient') as mock_jwk_client:
+            instance = mock_jwk_client.return_value
+            instance.get_signing_key_from_jwt.return_value = jwk
+            with self.assertRaises(UnauthorizedException):
+                eos.run_eos_token_validation(token, ['foo']), 'abc'
+
+    def test_fails_when_issuer_is_wrong(self):
+        payload = dict(aus='foo', iss='Acme Industries', sub='abc')
+        token, jwk = _make_test_token_and_key(payload)
+        with mock.patch('driftbase.auth.eos.jwt.PyJWKClient') as mock_jwk_client:
+            instance = mock_jwk_client.return_value
+            instance.get_signing_key_from_jwt.return_value = jwk
+            with self.assertRaises(UnauthorizedException):
+                eos.run_eos_token_validation(token, ['foo']), 'abc'
+
+
+def _make_test_token_and_key(payload):
+    jwk = jwt.PyJWK.from_json(TEST_JWK)
+    return jwt.encode(payload=payload, key=jwk.key, algorithm='HS256'), jwk


### PR DESCRIPTION
- Validate OpenID tokens coming from the client, extracting the Epic
Account ID from it, and using that as the username
- This auth module attempts to improve on the standard implementation
for auth modules, as an example for cleaning up all of them at some
future time