### PR TITLE
[auth] Cleanup legacy auth

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -4,7 +4,7 @@ verify_ssl = true
 name = "pypi"
 
 [packages]
-python-drift = "==0.7.0"
+python-drift = "==0.9.0b1"
 #python-drift = {editable = true, extras = ["aws", "test"], path = "../drift"}
 gevent = "*"
 requests = "*"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "0fdf66674c21d1641c99c45da090c4c7e023a9747731e78b80d9a6441f44d683"
+            "sha256": "534726324d247eedd23e93401930bb412b07bd7bced269033765863db5d59708"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -56,19 +56,19 @@
         },
         "boto3": {
             "hashes": [
-                "sha256:06ec67884fe9a24a95562d83c5defe4fd3b71ee6065a63de67335b443c376532",
-                "sha256:e4d0af77eb53e69adf2c77296c6cb408d8b168088905446d718bcfdab633d274"
+                "sha256:2fb05cbe81b9ce11d9394fc6c4ffa5fd1cceb114dc1d2887dc61081707e44522",
+                "sha256:aa4efdb811476a9e6c6fdf7c4595e3aa4258834351d2f3af1d97c87c1180e3be"
             ],
             "index": "pypi",
-            "version": "==1.20.18"
+            "version": "==1.20.21"
         },
         "botocore": {
             "hashes": [
-                "sha256:1bf5134cfeca3188bdd96584efc1de71c24f27b8cb711a28a1a331d8d7fef2aa",
-                "sha256:a46fcc6a65c0ef44ec3e04e329ad2dd94cbcbc4a1e2987b56ec914fe052b6e5c"
+                "sha256:853828e871dff588d92b383a3cf5e93861e180b9ed43135e36c2e139a72e030e",
+                "sha256:d7f8e82cba38aa1e66015cab0a5ca3204503e90afc4695e97228e28329a14c04"
             ],
             "index": "pypi",
-            "version": "==1.23.18"
+            "version": "==1.23.21"
         },
         "cachetools": {
             "hashes": [
@@ -142,11 +142,11 @@
         },
         "charset-normalizer": {
             "hashes": [
-                "sha256:735e240d9a8506778cd7a453d97e817e536bb1fc29f4f6961ce297b9c7a917b0",
-                "sha256:83fcdeb225499d6344c8f7f34684c2981270beacc32ede2e669e94f7fa544405"
+                "sha256:1eecaa09422db5be9e29d7fc65664e6c33bd06f9ced7838578ba40d58bdf3721",
+                "sha256:b0b883e8e874edfdece9c28f314e3dd5badf067342e42fb162203335ae61aa2c"
             ],
             "markers": "python_version >= '3'",
-            "version": "==2.0.8"
+            "version": "==2.0.9"
         },
         "click": {
             "hashes": [
@@ -684,11 +684,11 @@
         },
         "python-drift": {
             "hashes": [
-                "sha256:87c0eb70eac0bd6607fdbc916975c8b3957ceb324e6642331a6bc7d74d9d3b58",
-                "sha256:c8aded3bcb4cdd8b1157149f3fac155aa09ec5f3771862e509c8ae9e79f3b293"
+                "sha256:2a097a3822061fd270b9618940d1eaf37044baf4d449bfefd85d8356e153c22c",
+                "sha256:731885dd4d3602df0b418b54e52dd69d91b48547debf970688d3859517f91c4f"
             ],
             "index": "pypi",
-            "version": "==0.7.0"
+            "version": "==0.9.0b1"
         },
         "python-driftconfig": {
             "hashes": [
@@ -960,11 +960,11 @@
         },
         "charset-normalizer": {
             "hashes": [
-                "sha256:735e240d9a8506778cd7a453d97e817e536bb1fc29f4f6961ce297b9c7a917b0",
-                "sha256:83fcdeb225499d6344c8f7f34684c2981270beacc32ede2e669e94f7fa544405"
+                "sha256:1eecaa09422db5be9e29d7fc65664e6c33bd06f9ced7838578ba40d58bdf3721",
+                "sha256:b0b883e8e874edfdece9c28f314e3dd5badf067342e42fb162203335ae61aa2c"
             ],
             "markers": "python_version >= '3'",
-            "version": "==2.0.8"
+            "version": "==2.0.9"
         },
         "codecov": {
             "hashes": [

--- a/driftbase/auth/__init__.py
+++ b/driftbase/auth/__init__.py
@@ -1,9 +1,8 @@
-import importlib
 import functools
+import importlib
 
-from drift.utils import get_config
 from drift.core.extensions import jwt
-
+from drift.utils import get_config
 
 AUTH_MODULES = {
     'gamecenter': 'driftbase.auth.gamecenter',
@@ -16,7 +15,7 @@ AUTH_MODULES = {
 }
 
 LOCAL_AUTH = [
-    'device_id', 'user+pass', 'uuid', 'unit_test', 'viveport', 'hypereal', '7663',
+    'device_id', 'user+pass', 'uuid', 'viveport', 'hypereal', '7663',
 ]
 
 
@@ -27,7 +26,6 @@ def _authentication_thunker(module, func, *args, **kw):
 
 
 def drift_init_extension(app, api, **kwds):
-
     # register authentication handlers
     for name, module in AUTH_MODULES.items():
         jwt.register_auth_provider(app, name, functools.partial(_authentication_thunker, module, 'authenticate'))

--- a/driftbase/systesthelper.py
+++ b/driftbase/systesthelper.py
@@ -1,0 +1,10 @@
+from drift.systesthelper import DriftTestCase
+
+
+class DriftBaseTestCase(DriftTestCase):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+
+        # Override unit test auth provider, as we rely on auth potentially creating actual users
+        cls.auth_provider = 'user+pass'

--- a/driftbase/tests/auth/test_epic.py
+++ b/driftbase/tests/auth/test_epic.py
@@ -3,6 +3,7 @@ import unittest
 from driftbase.auth.epic import run_ticket_validation
 from driftbase.utils.test_utils import BaseCloudkitTest
 
+
 class EpicCase(BaseCloudkitTest):
 
     def test_epic(self):
@@ -10,9 +11,9 @@ class EpicCase(BaseCloudkitTest):
         auth_info = {
             'provider': 'epic',
             'provider_details':
-            {
-                'account_id': account_id,
-            }
+                {
+                    'account_id': account_id,
+                }
         }
 
         # Straight call
@@ -26,5 +27,6 @@ class EpicCase(BaseCloudkitTest):
 
 if __name__ == "__main__":
     import logging
+
     logging.basicConfig(level='INFO')
     unittest.main()

--- a/driftbase/tests/auth/test_jwt.py
+++ b/driftbase/tests/auth/test_jwt.py
@@ -1,15 +1,16 @@
 import contextlib
 import http
 import unittest
-
-from driftbase.utils.test_utils import BaseCloudkitTest
-from drift.core.extensions.jwt import jwt_not_required, check_jwt_authorization, requires_roles
 from flask.views import MethodView
+
+from drift.core.extensions.jwt import jwt_not_required, check_jwt_authorization, requires_roles
 from drift.utils import get_config
+from driftbase.utils.test_utils import BaseCloudkitTest
 
 ACCESS_KEY = "ThisIsMySecret"
 ROLE_NAME = "test_role"
 USER_NAME = "test_service_user"
+
 
 class TestJWTAccessControl(BaseCloudkitTest):
     @classmethod
@@ -82,7 +83,6 @@ class TestJWTAccessControl(BaseCloudkitTest):
             # This should fail as the post method requires role 'service' which we dont have
             self.post("/testapi", expected_status_code=http.HTTPStatus.UNAUTHORIZED)
             self.post("/trivialfunctions", expected_status_code=http.HTTPStatus.UNAUTHORIZED)
-
 
     @contextlib.contextmanager
     def _managed_bearer_token_user(self):
@@ -178,17 +178,19 @@ class TestAPI(MethodView):
 def get_trivial():
     return {}, http.HTTPStatus.OK
 
+
 def put_trivial():
     return {}, http.HTTPStatus.OK
+
 
 @requires_roles("service")
 def post_rolecheck():
     return {}, http.HTTPStatus.OK
 
+
 @jwt_not_required
 def get_no_check():
     return {}, http.HTTPStatus.OK
-
 
 
 if __name__ == "__main__":

--- a/driftbase/tests/auth/test_oculus.py
+++ b/driftbase/tests/auth/test_oculus.py
@@ -1,9 +1,9 @@
-import unittest
-import mock
 from json import loads, dumps
 
+import mock
 import requests
-from werkzeug.exceptions import Unauthorized, ServiceUnavailable
+import unittest
+from werkzeug.exceptions import Unauthorized
 
 from driftbase.auth.oculus import run_ticket_validation
 
@@ -11,7 +11,6 @@ patcher = None
 
 
 def setUpModule():
-
     original_post = requests.post
 
     def requests_post_mock(url, *args, **kw):
@@ -49,7 +48,6 @@ def tearDownModule():
 
 
 class OculusCase(unittest.TestCase):
-
     nonce = "140000003DED3A"
 
     def test_broken_url(self):
@@ -73,7 +71,9 @@ class OculusCase(unittest.TestCase):
             oculus_id = run_ticket_validation(user_id=123, access_token='badargs-token', nonce=self.nonce)
         self.assertIn("User 123 not authenticated on Oculus platform.", context.exception.description)
 
+
 if __name__ == "__main__":
     import logging
+
     logging.basicConfig(level='INFO')
     unittest.main()

--- a/driftbase/tests/auth/test_psn.py
+++ b/driftbase/tests/auth/test_psn.py
@@ -1,7 +1,7 @@
-import unittest
-import mock
 from json import loads, dumps
 
+import mock
+import unittest
 from werkzeug.exceptions import Unauthorized
 
 from driftbase.auth.psn import run_ticket_validation

--- a/driftbase/tests/players/test_counters.py
+++ b/driftbase/tests/players/test_counters.py
@@ -1,11 +1,11 @@
 # -*- coding: utf-8 -*-
 
-import unittest
 import datetime
-
 import http.client as http_client
+import unittest
 
-from drift.systesthelper import setup_tenant, remove_tenant, uuid_string, DriftBaseTestCase
+from drift.systesthelper import setup_tenant, remove_tenant, uuid_string
+from driftbase.systesthelper import DriftBaseTestCase
 
 
 def setUpModule():

--- a/driftbase/tests/players/test_gamestate.py
+++ b/driftbase/tests/players/test_gamestate.py
@@ -1,10 +1,10 @@
-import unittest
 import datetime
-import json
-
 import http.client as http_client
+import json
+import unittest
 
-from drift.systesthelper import setup_tenant, remove_tenant, uuid_string, DriftBaseTestCase
+from drift.systesthelper import setup_tenant, remove_tenant, uuid_string
+from driftbase.systesthelper import DriftBaseTestCase
 
 
 def setUpModule():

--- a/driftbase/tests/players/test_journal.py
+++ b/driftbase/tests/players/test_journal.py
@@ -1,12 +1,12 @@
 import datetime
-import unittest
-import random
+import http.client as http_client
 import json
+import random
+import unittest
 from dateutil import parser
 
-import http.client as http_client
-
-from drift.systesthelper import setup_tenant, remove_tenant, uuid_string, DriftBaseTestCase
+from drift.systesthelper import setup_tenant, remove_tenant, uuid_string
+from driftbase.systesthelper import DriftBaseTestCase
 
 MIN_ENTRIES = 0
 
@@ -129,7 +129,8 @@ class JournalTests(DriftBaseTestCase):
         # Make sure we cannot write a rolled-back journal entry into a gamestate
         gamestate_data = {"journal gamestate": "test"}
         r = self.put(gamestate_url, data={"gamestate": json.dumps(gamestate_data),
-                     "journal_id": journal_id}, expected_status_code=http_client.UNPROCESSABLE_ENTITY)
+                                          "journal_id": journal_id},
+                     expected_status_code=http_client.UNPROCESSABLE_ENTITY)
 
         # Roll back a few entries and ensure they are not returned from
         # a GET to /journals except if asked for

--- a/driftbase/tests/players/test_playergroups.py
+++ b/driftbase/tests/players/test_playergroups.py
@@ -1,7 +1,6 @@
 import http.client as http_client
 
 from drift.systesthelper import setup_tenant, remove_tenant
-
 from driftbase.utils.test_utils import BaseCloudkitTest
 
 
@@ -16,7 +15,6 @@ def tearDownModule():
 class PlayerGroupsTest(BaseCloudkitTest):
 
     def test_playergroups(self):
-
         self.auth()
 
         def pg_url(group_name):
@@ -91,11 +89,10 @@ class PlayerGroupsTest(BaseCloudkitTest):
         r = self.put(pg_url('empty'), data={'player_ids': []})
         self.assertEqual(len(r.json()['players']), 0)
         r = self.put(pg_url('not_found'), data={'player_ids': [123456],
-                     'identity_names': ['nobody']})
+                                                'identity_names': ['nobody']})
         self.assertEqual(len(r.json()['players']), 0)
 
     def test_players_with_group(self):
-
         self.make_player(username="Number one user")
         p1 = self.player_id
         self.make_player(username="Number two user")

--- a/driftbase/tests/players/test_players.py
+++ b/driftbase/tests/players/test_players.py
@@ -1,7 +1,8 @@
 import datetime
 import http.client as http_client
-from mock import patch
 import unittest
+from mock import patch
+
 from drift.systesthelper import uuid_string, big_number
 from driftbase.utils.test_utils import BaseCloudkitTest
 
@@ -10,6 +11,7 @@ class PlayersTest(BaseCloudkitTest):
     """
     Tests for the /players endpoints
     """
+
     def test_players_online(self):
         # create a new user and client
         self.make_player()
@@ -20,7 +22,8 @@ class PlayersTest(BaseCloudkitTest):
 
         # mock out the utcnow call so that we can put the players 'offline'
         with patch("driftbase.models.db.utcnow") as mock_date:
-            mock_date.return_value = datetime.datetime.utcnow() + datetime.timedelta(minutes=5, seconds=1)  # Insert fudge because of clock drift on vm's
+            mock_date.return_value = datetime.datetime.utcnow() + datetime.timedelta(minutes=5,
+                                                                                     seconds=1)  # Insert fudge because of clock drift on vm's
             r = self.get(self.endpoints["my_player"])
             self.assertFalse(r.json()["is_online"])
 
@@ -99,7 +102,8 @@ class PlayersTest(BaseCloudkitTest):
         self.auth()
         player_name = "Spicy Meatball"
         self.patch(self.endpoints["my_player"], data={"name": player_name})
-        for search_string in (player_name, "*icy*"): # Test that both exact, case-sensitive and valid fuzzy searches return a result
+        for search_string in (
+        player_name, "*icy*"):  # Test that both exact, case-sensitive and valid fuzzy searches return a result
             players = self.get(self.endpoints["players"] + "?player_name=%s" % search_string).json()
             self.assertIsInstance(players, list)
             self.assertTrue(len(players) == 1)

--- a/driftbase/tests/players/test_summary.py
+++ b/driftbase/tests/players/test_summary.py
@@ -1,5 +1,4 @@
 import copy
-
 import http.client as http_client
 
 from drift.systesthelper import setup_tenant, remove_tenant

--- a/driftbase/tests/test_auth.py
+++ b/driftbase/tests/test_auth.py
@@ -1,8 +1,9 @@
-from mock import patch, MagicMock
 import http.client as http_client
+from mock import patch, MagicMock
 
-from drift.systesthelper import setup_tenant, remove_tenant, DriftBaseTestCase
+from drift.systesthelper import setup_tenant, remove_tenant
 from drift.utils import get_config
+from driftbase.systesthelper import DriftBaseTestCase
 
 
 def setUpModule():

--- a/driftbase/tests/test_clients.py
+++ b/driftbase/tests/test_clients.py
@@ -1,7 +1,6 @@
-import json
 import datetime
-
 import http.client as http_client
+import json
 from mock import patch
 
 from driftbase.utils.test_utils import BaseCloudkitTest
@@ -11,6 +10,7 @@ class ClientsTest(BaseCloudkitTest):
     """
     Tests for the /clients endpoint
     """
+
     def test_clients(self):
         self.auth()
         clients_url = self.endpoints["clients"]
@@ -155,7 +155,8 @@ class ClientsTest(BaseCloudkitTest):
 
         # Accept the g1 invite
         self.auth(g1_name)
-        g1_notification, g1_message_number = notification, _ = self.get_player_notification("party_notification", "invite")
+        g1_notification, g1_message_number = notification, _ = self.get_player_notification("party_notification",
+                                                                                            "invite")
         self.patch(g1_notification['invite_url'], data={'inviter_id': host_id}, expected_status_code=http_client.OK)
 
         # Assert host in party

--- a/driftbase/tests/test_counters.py
+++ b/driftbase/tests/test_counters.py
@@ -1,7 +1,8 @@
 import datetime
-
 import http.client as http_client
-from drift.systesthelper import setup_tenant, remove_tenant, DriftBaseTestCase, uuid_string
+
+from drift.systesthelper import setup_tenant, remove_tenant, uuid_string
+from driftbase.systesthelper import DriftBaseTestCase
 
 
 def setUpModule():
@@ -16,6 +17,7 @@ class CountersTest(DriftBaseTestCase):
     """
     Tests for the /counters endpoint
     """
+
     def test_counters_put(self):
         # verify that the temporary put versions of the patch endpoints work
         self.auth(username=uuid_string())

--- a/driftbase/tests/test_events.py
+++ b/driftbase/tests/test_events.py
@@ -1,10 +1,9 @@
 import datetime
-
-import mock
 import http.client as http_client
+import mock
 
-from drift.systesthelper import DriftBaseTestCase
 from drift.core.extensions.jwt import current_user
+from driftbase.systesthelper import DriftBaseTestCase
 
 
 class EventsTest(DriftBaseTestCase):

--- a/driftbase/tests/test_machinegroups.py
+++ b/driftbase/tests/test_machinegroups.py
@@ -1,11 +1,13 @@
 import http.client as http_client
-from drift.systesthelper import DriftBaseTestCase
+
+from driftbase.systesthelper import DriftBaseTestCase
 
 
 class MachineGroupsTest(DriftBaseTestCase):
     """
     Tests for the /machines service endpoints
     """
+
     def test_machinegroup_create(self):
         self.auth_service()
         data = {

--- a/driftbase/tests/test_machines.py
+++ b/driftbase/tests/test_machines.py
@@ -1,10 +1,9 @@
 import datetime
+import http.client as http_client
 from unittest.mock import patch
 
-from drift.systesthelper import DriftBaseTestCase
-import http.client as http_client
-
 from driftbase.api.machines import MachinesPostResponseSchema, MachinePutResponseSchema
+from driftbase.systesthelper import DriftBaseTestCase
 
 
 class MachinesTest(DriftBaseTestCase):

--- a/driftbase/tests/test_runconfigs.py
+++ b/driftbase/tests/test_runconfigs.py
@@ -1,12 +1,15 @@
-import unittest
 import http.client as http_client
-from drift.systesthelper import DriftBaseTestCase, make_unique
+import unittest
+
+from drift.systesthelper import make_unique
+from driftbase.systesthelper import DriftBaseTestCase
 
 
 class RunConfigsTest(DriftBaseTestCase):
     """
     Tests for the /machines service endpoints
     """
+
     def test_runconfig_create(self):
         self.auth_service()
         data = {

--- a/driftbase/tests/test_servers.py
+++ b/driftbase/tests/test_servers.py
@@ -1,11 +1,10 @@
 import copy
 import datetime
+import http.client as http_client
 from unittest.mock import patch
 
-from drift.systesthelper import DriftBaseTestCase
-import http.client as http_client
-
 from driftbase.api.servers import ServersPostResponseSchema, ServerPutResponseSchema, ServerHeartbeatPutResponseSchema
+from driftbase.systesthelper import DriftBaseTestCase
 
 
 class ServersTest(DriftBaseTestCase):
@@ -161,7 +160,8 @@ class ServersTest(DriftBaseTestCase):
         url = resp["url"]
         resp = self.get(url).json()
         self.assertEqual(resp["heartbeat_count"], 0)
-        heartbeat_date = datetime.datetime.fromisoformat(resp["heartbeat_date"][:-1]) - datetime.timedelta(seconds=1)  # Insert fudge because of clock drift on vm's
+        heartbeat_date = datetime.datetime.fromisoformat(resp["heartbeat_date"][:-1]) - datetime.timedelta(
+            seconds=1)  # Insert fudge because of clock drift on vm's
         heartbeat_url = self.get(url).json()["heartbeat_url"]
         resp = self.put(heartbeat_url).json()
         self.assertDictEqual(ServerHeartbeatPutResponseSchema().validate(resp), {})

--- a/driftbase/tests/test_staticdata.py
+++ b/driftbase/tests/test_staticdata.py
@@ -1,12 +1,14 @@
 """
     Tests for the static data endpoints
 """
-import unittest
-import responses
 import json
-import os
+import responses
+import unittest
+
+from drift.systesthelper import setup_tenant, remove_tenant
 from drift.utils import get_config
-from drift.systesthelper import setup_tenant, remove_tenant, DriftBaseTestCase
+from driftbase.systesthelper import DriftBaseTestCase
+
 
 def setUpModule():
     setup_tenant()
@@ -52,7 +54,8 @@ class CfgTest(DriftBaseTestCase):
         urls = resp.get("static_data_urls")
         self.assertIsNotNone(urls, "The 'static_data_urls' key is missing")
         self.assertTrue(len(urls) > 0, "There should be at least one entry in 'static_data_urls'.")
-        self.assertEqual(urls[0]["data_root_url"], u"{}{}/data/{}/".format(DATA_URL, "borko-games/the-ossomizer", "abcd"))
+        self.assertEqual(urls[0]["data_root_url"],
+                         u"{}{}/data/{}/".format(DATA_URL, "borko-games/the-ossomizer", "abcd"))
         self.assertEqual(urls[0]["origin"], "Tenant config")
         self.assertEqual(urls[0]["commit_id"], ref1["commit_id"], "I should have gotten the default ref.")
 

--- a/driftbase/tests/test_useridentities.py
+++ b/driftbase/tests/test_useridentities.py
@@ -1,5 +1,7 @@
 import http.client as http_client
-from drift.systesthelper import uuid_string, DriftBaseTestCase
+
+from drift.systesthelper import uuid_string
+from driftbase.systesthelper import DriftBaseTestCase
 from driftbase.tests import has_key
 
 

--- a/driftbase/tests/test_users.py
+++ b/driftbase/tests/test_users.py
@@ -1,7 +1,7 @@
 import http.client as http_client
 
-from drift.systesthelper import DriftBaseTestCase, big_number
-
+from drift.systesthelper import big_number
+from driftbase.systesthelper import DriftBaseTestCase
 from driftbase.tests import has_key
 
 
@@ -9,6 +9,7 @@ class UsersTest(DriftBaseTestCase):
     """
     Tests for the /users endpoint
     """
+
     def test_users(self):
         self.auth()
         resp = self.get("/")

--- a/driftbase/utils/test_utils.py
+++ b/driftbase/utils/test_utils.py
@@ -2,7 +2,8 @@
     Utilities functions assisting the system tests
 """
 import http.client as http_client
-from drift.systesthelper import uuid_string, DriftBaseTestCase
+from drift.systesthelper import uuid_string
+from driftbase.systesthelper import DriftBaseTestCase
 
 
 class BaseCloudkitTest(DriftBaseTestCase):


### PR DESCRIPTION
Drift 0.9.0 clears up some bits in the authentication API which are being adapted here.

This was initially implemented in feature/cleanup-auth, but I fail to rebase or merge that branch without breaking all authentication with the DB during tests.