### PR TITLE
Allow service users to lookup users via steam id. Model the response …

### DIFF
--- a/driftbase/auth/authenticate.py
+++ b/driftbase/auth/authenticate.py
@@ -161,6 +161,8 @@ def authenticate(username, password, automatic_account_creation=True):
                      my_identity.identity_id)
         else:
             my_user = User(user_name=username)
+            if my_identity.identity_type:
+                my_user.provider = identity_type
             g.db.add(my_user)
             # this is so we can access the auto-increment key value
             g.db.flush()

--- a/driftbase/tests/test_users.py
+++ b/driftbase/tests/test_users.py
@@ -3,6 +3,8 @@ import http.client as http_client
 from drift.systesthelper import big_number
 from driftbase.systesthelper import DriftBaseTestCase
 from driftbase.tests import has_key
+from drift.utils import get_config
+from mock import patch, MagicMock
 
 
 class UsersTest(DriftBaseTestCase):
@@ -33,3 +35,66 @@ class UsersTest(DriftBaseTestCase):
         self.assertIn("error", r.json())
         self.assertIn("code", r.json()["error"])
         self.assertIn("Authorization Required", r.json()["error"]["description"])
+
+
+class SteamUsersTest(DriftBaseTestCase):
+    """
+    Tests for the /users/steam/ endpoint
+    """
+    app_id = 12345
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        conf = get_config()
+        conf.table_store.get_table('platforms').add({
+            'product_name': conf.product['product_name'],
+            'provider_name': 'steam',
+            "provider_details": {
+                "appid": cls.app_id,
+                "key": "steam key"
+            }})
+
+    @classmethod
+    def tearDownClass(cls):
+        conf = get_config()
+        conf.table_store.get_table('platforms').remove({
+            'product_name': conf.product['product_name'],
+            'provider_name': 'steam',
+            "provider_details": {
+                "appid": cls.app_id,
+                "key": "steam key"
+            }})
+        super().tearDownClass()
+
+    def test_get_user_by_steam_id(self):
+        steam_id = 1234567890
+        user_data = {
+            "provider": "steam",
+            "provider_details": {
+                "ticket": "tick",
+                "appid": self.app_id,
+                "steamid": str(steam_id)
+            }
+        }
+        # Setup steam user
+        with patch('driftbase.auth.steam._call_authenticate_user_ticket') as mocked_auth:
+            mocked_auth.return_value.status_code = 200
+            mocked_auth.return_value.json = MagicMock()
+            mocked_auth.return_value.json.return_value = {'response': {'params': {'steamid': str(steam_id)}}}
+            with patch('driftbase.auth.steam._call_check_app_ownership') as mocked_own:
+                mocked_own.return_value.status_code = 200
+                self.post('/auth', data=user_data)
+        # Test for success
+        with self.as_bearer_token_user("service"):
+            self.get(f"/users/steam/{steam_id+123}", expected_status_code=http_client.NOT_FOUND)
+            r = self.get(f"/users/steam/{steam_id}", expected_status_code=http_client.OK).json()
+            self.assertIn("create_date", r)
+            self.assertIn("players", r)
+            self.assertEqual(len(r["players"]), 1)
+            player_info = r["players"][0]
+            self.assertIn("player_name", player_info)
+            self.assertIn("player_id", player_info)
+        # Should not be accessible by non-service users
+        self.get(f"/users/steam/{steam_id}", expected_status_code=http_client.UNAUTHORIZED)
+        self.auth()
+        self.get(f"/users/steam/{steam_id}", expected_status_code=http_client.UNAUTHORIZED)


### PR DESCRIPTION
…on the existing endpoint.