### PR TITLE
Feature/support multiple steam apps per tenant

### DIFF
--- a/driftbase/auth/steam.py
+++ b/driftbase/auth/steam.py
@@ -58,7 +58,7 @@ def validate_steam_ticket():
     appid = int(provider_details.get('appid'))
     appids = [steam_config.get('appid'), steam_config.get('playtest_appid')]
     supported_appids = list(filter(lambda id: id is not None, appids))
-    if not appid in supported_appids:
+    if appid not in supported_appids:
         abort(http_client.SERVICE_UNAVAILABLE, description="Steam authentication not configured for app %s." % appid)
 
     # Look up our secret key or key url

--- a/driftbase/auth/steam.py
+++ b/driftbase/auth/steam.py
@@ -56,7 +56,9 @@ def validate_steam_ticket():
 
     # Find configuration for the requested Steam app id.
     appid = int(provider_details.get('appid'))
-    if steam_config['appid'] != appid:
+    appids = [steam_config.get('appid'), steam_config.get('playtest_appid')]
+    supported_appids = list(filter(lambda id: id is not None, appids))
+    if not appid in supported_appids:
         abort(http_client.SERVICE_UNAVAILABLE, description="Steam authentication not configured for app %s." % appid)
 
     # Look up our secret key or key url


### PR DESCRIPTION
In the event that one needs to run a steam playtest build on the same tenant as the live game, the steam config must support multiple app IDs. This change adds an optional playtest_appid to the steam auth config and either one or both are supported.