### PR TITLE
Fix 500 errors on eos, gamecenter and ethereum /auth

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,7 +66,7 @@
 ## 0.7.0
 
 ### New features
-- New auth provider 'etherium' added
+- New auth provider 'ethereum' added
 
 ### Bug Fixes / Feature Improvements
 - Support gzipped payloads in events endpoint

--- a/driftbase/auth/eos.py
+++ b/driftbase/auth/eos.py
@@ -8,7 +8,7 @@ from datetime import timedelta
 from flask_smorest import abort
 from jwt import PyJWKClientError
 from urllib.error import URLError
-from werkzeug.security import pbkdf2_hex
+from hashlib import pbkdf2_hmac
 
 from driftbase.auth import get_provider_config
 from .authenticate import authenticate as base_authenticate, AuthenticationException, ServiceUnavailableException, \
@@ -50,7 +50,7 @@ def authenticate(auth_info):
 
     automatic_account_creation = auth_info.get('automatic_account_creation', True)
     # FIXME: The static salt should perhaps be configured per tenant
-    username = "eos:" + pbkdf2_hex(identity_id, 'static_salt', iterations=1)
+    username = "eos:" + pbkdf2_hmac('sha256', identity_id.encode('utf-8'), b'static_salt', iterations=1).hex()
     return base_authenticate(username, "", automatic_account_creation)
 
 

--- a/driftbase/auth/ethereum.py
+++ b/driftbase/auth/ethereum.py
@@ -8,7 +8,7 @@ import marshmallow as ma
 from eth_account import Account
 from eth_account.messages import encode_defunct
 from flask_smorest import abort
-from werkzeug.security import pbkdf2_hex
+from hashlib import pbkdf2_hmac
 
 from driftbase.auth import get_provider_config
 from .authenticate import authenticate as base_authenticate, AuthenticationException, ServiceUnavailableException, \
@@ -50,7 +50,7 @@ def authenticate(auth_info):
 
     automatic_account_creation = auth_info.get('automatic_account_creation', True)
     # FIXME: The static salt should perhaps be configured per tenant
-    username = "ethereum:" + pbkdf2_hex(identity_id, 'static_salt', iterations=1)
+    username = "ethereum:" + pbkdf2_hmac('sha256', identity_id.encode('utf-8'), b'static_salt', iterations=1).hex()
     return base_authenticate(username, "", automatic_account_creation)
 
 

--- a/driftbase/auth/gamecenter.py
+++ b/driftbase/auth/gamecenter.py
@@ -7,7 +7,7 @@ from flask_smorest import abort
 import http.client as http_client
 from six.moves.urllib.parse import urlparse
 from werkzeug.exceptions import Unauthorized
-from werkzeug.security import pbkdf2_hex
+from hashlib import pbkdf2_hmac
 
 from driftbase.auth import get_provider_config
 from driftbase.auth.util import fetch_url
@@ -24,8 +24,8 @@ def authenticate(auth_info):
     identity_id = validate_gamecenter_token(provider_details)
     # The GameCenter user_id cannot be stored in plain text, so let's
     # give it one cycle of hashing.
-    username = "gamecenter:" + pbkdf2_hex(identity_id, "staticsalt",
-                                          iterations=1)
+    username = "gamecenter:" + pbkdf2_hmac('sha256', identity_id.encode('utf-8'), b"staticsalt",
+                                           iterations=1).hex()
     return base_authenticate(username, "", automatic_account_creation)
 
 

--- a/driftbase/tests/auth/test_eos.py
+++ b/driftbase/tests/auth/test_eos.py
@@ -1,12 +1,13 @@
+import json
+import unittest
 from unittest import mock
 
-import json
 import jwt
-import unittest
 
 import driftbase.auth.eos as eos
 from driftbase.auth.authenticate import InvalidRequestException, ServiceUnavailableException, \
     UnauthorizedException
+from driftbase.tests.test_auth import BaseAuthTestCase
 
 # Examples from https://tools.ietf.org/html/rfc7518, https://tools.ietf.org/html/rfc7519
 TEST_JWT = 'eyJ0eXAiOiJKV1QiLA0KICJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJqb2UiLA0KICJleHAiOjEzMDA4MTkzODAsDQogImh0dHA6Ly9leGFtcGxlLmNvbS9pc19yb290Ijp0cnVlfQ.dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk'
@@ -144,3 +145,31 @@ class TestEosRunAuthentication(unittest.TestCase):
 def _make_test_token_and_key(payload):
     jwk = jwt.PyJWK.from_json(TEST_JWK)
     return jwt.encode(payload=payload, key=jwk.key, algorithm=TEST_JWT_ALGORITHM), jwk
+
+
+@mock.patch('driftbase.auth.eos.JWT_ALGORITHM', TEST_JWT_ALGORITHM)
+class ProviderDetailsTests(BaseAuthTestCase):
+    def setUp(self):
+        self.token_audience = 'foo'
+        self.valid_client_ids = [self.token_audience]
+        self.expected_sub = 'eos_account_id'
+
+    def make_provider_data(self, token):
+        return {
+            'provider': 'eos',
+            'provider_details': {
+                'token': token,
+            }
+        }
+
+    def test_auth(self):
+        with mock.patch('driftbase.auth.eos.get_provider_config') as config:
+            config.return_value = dict(client_ids=[self.token_audience])
+            payload = dict(aud=self.token_audience, iss=eos.TRUSTED_ISSUER_URL_BASE, sub=self.expected_sub)
+            token, jwk = _make_test_token_and_key(payload)
+            with mock.patch('driftbase.auth.eos._get_key_from_token', return_value=jwk.key):
+                user1 = self._auth_and_get_user(self.make_provider_data(token))
+            token, jwk = _make_test_token_and_key(payload)
+            with mock.patch('driftbase.auth.eos._get_key_from_token', return_value=jwk.key):
+                user2 = self._auth_and_get_user(self.make_provider_data(token))
+            assert user1['identity_id'] == user2['identity_id']

--- a/driftbase/tests/auth/test_ethereum.py
+++ b/driftbase/tests/auth/test_ethereum.py
@@ -1,11 +1,11 @@
-from unittest import mock
-
 import datetime
 import unittest
+from unittest import mock
 
 import driftbase.auth.ethereum as ethereum
 from driftbase.auth.authenticate import InvalidRequestException, ServiceUnavailableException, \
     UnauthorizedException
+from driftbase.tests.test_auth import BaseAuthTestCase
 
 
 class TestEthereumAuthenticate(unittest.TestCase):
@@ -126,3 +126,26 @@ class TestEthereumRunAuthentication(unittest.TestCase):
             now.return_value = self.timestamp - datetime.timedelta(seconds=10)
             with self.assertRaises(UnauthorizedException):
                 ethereum._run_ethereum_message_validation(self.address, self.message, self.signature)
+
+
+signature_timestamp = datetime.datetime.fromisoformat('2022-01-12T08:12:59.787')
+
+ethereum_data = {
+    'provider': 'ethereum',
+    'provider_details': {
+        'signer': '0x854Cc1Ce8e826e514f1dD8127f9D0AF689f181A9',
+        'message': '{\r\n\t"message": "Authorize for Drift login",\r\n\t"timestamp": "2022-01-12T08:12:59.787Z"\r\n}',
+        'signature': '0x5b0bf23f6cccf4315f561a04aef11b60dadced91bc17ac168db14b467851d4010349a8d3fbaec28c4671eb27ba7a8160900b51c2ded5137b3a9804881f3ee32c1c',
+    }
+}
+
+
+class ProviderDetailsTests(BaseAuthTestCase):
+    def test_auth(self):
+        with mock.patch('driftbase.auth.ethereum.utcnow') as now:
+            now.return_value = signature_timestamp + datetime.timedelta(seconds=5)
+            with mock.patch('driftbase.auth.ethereum.get_provider_config') as config:
+                config.return_value = dict()
+                user1 = self._auth_and_get_user(ethereum_data)
+                user2 = self._auth_and_get_user(ethereum_data)
+                assert user1['identity_id'] == user2['identity_id']

--- a/driftbase/tests/auth/test_gamecenter.py
+++ b/driftbase/tests/auth/test_gamecenter.py
@@ -175,9 +175,3 @@ class GameCenterCase(unittest.TestCase):
             return self
         else:
             return GameCenterCase.orig_get(url, *args, **kw)
-
-
-if __name__ == "__main__":
-    import logging
-    logging.basicConfig(level='INFO')
-    unittest.main()

--- a/driftbase/tests/test_auth.py
+++ b/driftbase/tests/test_auth.py
@@ -1,8 +1,9 @@
 import http.client as http_client
-from mock import patch, MagicMock
 
 from drift.systesthelper import setup_tenant, remove_tenant
 from drift.utils import get_config
+from mock import patch, MagicMock
+
 from driftbase.systesthelper import DriftBaseTestCase
 
 
@@ -161,12 +162,14 @@ uuid_auth_with_provider_data = {
 }
 
 
-class BaseAuthTests(DriftBaseTestCase):
+class BaseAuthTestCase(DriftBaseTestCase):
     def _auth_and_get_user(self, data):
         token1 = self.post('/auth', data=data, expected_status_code=http_client.OK)
         user1 = self.get('/', headers={'Authorization': f"BEARER {token1.json()['token']}"}).json()['current_user']
         return user1
 
+
+class UserPassAuthTests(BaseAuthTestCase):
     def test_old_style_user_pass_auth(self):
         user1 = self._auth_and_get_user(old_style_user_pass_data)
         user2 = self._auth_and_get_user(old_style_user_pass_data)


### PR DESCRIPTION
- Previous tests did not excecise the API code path which used the new hashing library, and nobody used this on DEV for some time, so it was not found out until now.