### PR TITLE
Add failure if running make local-config if expect isn't installed

### DIFF
--- a/scripts/create-config.sh
+++ b/scripts/create-config.sh
@@ -22,6 +22,13 @@ driftconfig push -f $CONFIG
 
 driftconfig register
 
+if ! command -v expect; then
+    RED='\033[0;31m'
+    RESET='\033[0m'
+    echo -e "${RED}Error: expect is not installed. Please install it and try again.${RESET}"
+    exit 1
+fi
+
 # These inputs are queried in random order
 expect <<EOF
 spawn driftconfig assign-tier $DEPLOYABLE --tiers $TIER

--- a/scripts/create-config.sh
+++ b/scripts/create-config.sh
@@ -1,5 +1,12 @@
 #!/usr/bin/env bash
 
+if ! command -v expect; then
+    RED='\033[0;31m'
+    RESET='\033[0m'
+    echo -e "${RED}Error: expect is not installed. Please install it and try again.${RESET}"
+    exit 1
+fi
+
 DIR="${BASH_SOURCE%/*}"
 if [[ ! -d "$DIR" ]]; then DIR="$PWD"; fi
 
@@ -21,13 +28,6 @@ dconf product add $PRODUCT
 driftconfig push -f $CONFIG
 
 driftconfig register
-
-if ! command -v expect; then
-    RED='\033[0;31m'
-    RESET='\033[0m'
-    echo -e "${RED}Error: expect is not installed. Please install it and try again.${RESET}"
-    exit 1
-fi
 
 # These inputs are queried in random order
 expect <<EOF


### PR DESCRIPTION
Write out a pretty red line when trying to run make local-config without having 'expect' installed