### PR TITLE
[auth] Add support for cognito ID-token login

### DIFF
--- a/driftbase/api/useridentities.py
+++ b/driftbase/api/useridentities.py
@@ -15,7 +15,7 @@ from drift.core.extensions.jwt import current_user, get_cached_token
 from driftbase.models.db import User, CorePlayer, UserIdentity
 
 # Authentication types that hash their usernames
-HASHING_IDENTITY_PROVIDERS = ("eos", "ethereum", "gamecenter")
+HASHING_IDENTITY_PROVIDERS = ("eos", "ethereum", "gamecenter", "cognito")
 # Authentication types that used to hash their usernames, but now lazily convert them to clear text
 LEGACY_HASHING_IDENTITY_PROVIDERS = ("ethereum")
 

--- a/driftbase/auth/__init__.py
+++ b/driftbase/auth/__init__.py
@@ -13,6 +13,7 @@ AUTH_MODULES = {
     'epic': 'driftbase.auth.epic',
     'eos': 'driftbase.auth.eos',
     'ethereum': 'driftbase.auth.ethereum',
+    'cognito': 'driftbase.auth.cognito',
 }
 
 LOCAL_AUTH = [

--- a/driftbase/auth/cognito.py
+++ b/driftbase/auth/cognito.py
@@ -1,0 +1,162 @@
+"""
+Required platform configuration for Cognito authentication.
+
+client_ids: List of client IDs that are allowed to authenticate with this provider.
+user_pool_region: The AWS region where the user pool is located.
+user_pool_id: The ID of the user pool.
+"""
+
+import http.client as http_client
+import logging
+from datetime import timedelta
+from hashlib import pbkdf2_hmac
+from json import JSONDecodeError
+from urllib.error import URLError
+
+import jwt
+import marshmallow as ma
+from drift.blueprint import abort
+from jwt import PyJWKClientError
+
+from driftbase.auth import get_provider_config
+from .authenticate import authenticate as base_authenticate, AuthenticationException, ServiceUnavailableException, \
+    abort_unauthorized, InvalidRequestException, UnauthorizedException
+
+# See https://repost.aws/knowledge-center/decode-verify-cognito-json-token
+# for more information on how to validate a Cognito token.
+
+COGNITO_PUBLIC_KEYS_URL_TEMPLATE = "https://cognito-idp.{region}.amazonaws.com/{userPoolId}/.well-known/jwks.json"
+TRUSTED_ISSUER_URL_BASE = "https://cognito-idp.{region}.amazonaws.com/{userPoolId}"
+
+JWT_ALGORITHM = "RS256"
+JWT_LEEWAY = 10
+JWT_VERIFY_CLAIMS = ["signature", "exp", "iat"]
+JWT_REQUIRED_CLAIMS = ["exp", "iat", "sub"]
+
+log = logging.getLogger(__name__)
+
+
+class CognitoProviderAuthDetailsSchema(ma.Schema):
+    token = ma.fields.String(required=True, allow_none=False)
+
+
+def authenticate(auth_info):
+    assert auth_info['provider'] == 'cognito'
+
+    try:
+        parameters = _load_provider_details(auth_info['provider_details'])
+    except InvalidRequestException as e:
+        abort(http_client.BAD_REQUEST, message=e.msg)
+    except KeyError as e:
+        abort(http_client.BAD_REQUEST, message="Missing provider_details")
+
+    try:
+        identity_id = _validate_cognito_token(**parameters)
+    except ServiceUnavailableException as e:
+        abort(http_client.SERVICE_UNAVAILABLE, message=e.msg)
+    except InvalidRequestException as e:
+        abort(http_client.BAD_REQUEST, message=e.msg)
+    except AuthenticationException as e:
+        abort_unauthorized(e.msg)
+
+    automatic_account_creation = auth_info.get('automatic_account_creation', True)
+    # FIXME: The static salt should perhaps be configured per tenant
+
+    username = "cognito:" + pbkdf2_hmac('sha256', identity_id.encode('utf-8'), b'static_salt', iterations=1).hex()
+    return base_authenticate(username, "", automatic_account_creation)
+
+
+def _load_provider_details(provider_details):
+    try:
+        return CognitoProviderAuthDetailsSchema().load(provider_details)
+    except ma.exceptions.ValidationError as e:
+        raise InvalidRequestException(f"{e}") from None
+
+
+def _validate_cognito_token(token):
+    """Validates a Cognito OpenID token.
+
+    Returns the Cognito Account ID for this player.
+
+    The audience claim must match one of the configured client_ids for the product.
+
+    Example:
+
+    provider_details = {
+        "token": "ZuhbO8TqGKadYAZHsDd5NgTs/tmM8sIqhtxuUmxOlhmp8PUAofIYzdwaN..."
+    }
+
+    validate_cognito_token(provider_details)
+    """
+
+    cognito_config = get_provider_config('cognito')
+    if not cognito_config:
+        raise ServiceUnavailableException("Cognito authentication not configured for current tenant")
+
+    return _run_cognito_token_validation(
+        token,
+        cognito_config.get('client_ids'),
+        cognito_config.get('user_pool_region'),
+        cognito_config.get('user_pool_id')
+    )
+
+
+def _run_cognito_token_validation(token, client_ids, aws_region, user_pool_id):
+    public_keys_url = COGNITO_PUBLIC_KEYS_URL_TEMPLATE.format(
+        region=aws_region,
+        userPoolId=user_pool_id
+    )
+
+    public_key = _get_key_from_token(token, public_keys_url)
+    payload = _decode_and_verify_jwt(token, public_key, client_ids, aws_region, user_pool_id)
+
+    return payload["sub"]
+
+
+def _decode_and_verify_jwt(token, key, audience, aws_region, user_pool_id):
+    options = {
+        'verify_' + claim: True
+        for claim in JWT_VERIFY_CLAIMS
+    }
+
+    options.update({
+        'require_' + claim: True
+        for claim in JWT_REQUIRED_CLAIMS
+    })
+
+    try:
+        payload = jwt.decode(
+            jwt=token,
+            key=key,
+            options=options,
+            audience=audience,
+            algorithms=[JWT_ALGORITHM],
+            leeway=timedelta(seconds=JWT_LEEWAY)
+        )
+    except jwt.MissingRequiredClaimError as e:
+        raise UnauthorizedException(f"Invalid token: {str(e)}")
+    except jwt.InvalidTokenError as e:
+        raise UnauthorizedException(f"Invalid token: {str(e)}")
+
+    issuer = payload.get("iss")
+    if not issuer:
+        raise UnauthorizedException("Invalid JWT, no issuer found")
+    truset_issuer = TRUSTED_ISSUER_URL_BASE.format(region=aws_region, userPoolId=user_pool_id)
+    if not issuer.startswith(TRUSTED_ISSUER_URL_BASE):
+        raise UnauthorizedException("Invalid JWT, issuer not trusted")
+
+    return payload
+
+
+def _get_key_from_token(token, cognito_public_keys_url):
+    try:
+        jwk_client = jwt.PyJWKClient(cognito_public_keys_url)
+        jwk = jwk_client.get_signing_key_from_jwt(token)
+    except URLError as e:
+        raise ServiceUnavailableException("Failed to fetch public keys for token validation") from e
+    except (JSONDecodeError, PyJWKClientError) as e:
+        raise ServiceUnavailableException("Failed to read public keys for token validation") from None
+
+    if jwk is None:
+        raise UnauthorizedException("Failed to find a matching public key for token validation")
+    return jwk.key

--- a/tests/auth/test_cognito.py
+++ b/tests/auth/test_cognito.py
@@ -1,0 +1,195 @@
+import json
+import unittest
+from hashlib import pbkdf2_hmac
+from unittest import mock
+
+import jwt
+
+import driftbase.auth.cognito
+import driftbase.auth.cognito as cognito
+from driftbase.auth.authenticate import InvalidRequestException, ServiceUnavailableException, \
+    UnauthorizedException
+from tests.test_auth import BaseAuthTestCase
+
+# Examples from https://tools.ietf.org/html/rfc7518, https://tools.ietf.org/html/rfc7519
+TEST_JWT = 'eyJ0eXAiOiJKV1QiLA0KICJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJqb2UiLA0KICJleHAiOjEzMDA4MTkzODAsDQogImh0dHA6Ly9leGFtcGxlLmNvbS9pc19yb290Ijp0cnVlfQ.dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk'
+TEST_JWK = '{"kty":"oct", "k":"AyM1SysPpbyDfgZld3umj1qzKObwVMkoqQ-EstJQLr_T-1qS0gZH75aKtMN3Yj0iPS4hcgUuTwjAzZr1Z9CAow", "kid":"test"}'
+TEST_JWK_SET = '''{
+    "keys":[
+        {"kty":"oct", "k":"AyM1SysPpbyDfgZld3umj1qzKObwVMkoqQ-EstJQLr_T-1qS0gZH75aKtMN3Yj0iPS4hcgUuTwjAzZr1Z9CAow", "kid":"test"}
+    ]
+}'''
+TEST_JWT_ALGORITHM = 'HS256'
+TEST_USER_POOL_REGION = 'us-west-2'
+TEST_USER_POOL_ID = 'us-west-2_abc123'
+
+
+class TestEosAuthenticate(unittest.TestCase):
+    def test_fails_if_missing_or_incorrect_provider_name(self):
+        with self.assertRaises(KeyError):
+            cognito.authenticate(dict())
+        with self.assertRaises(AssertionError):
+            cognito.authenticate(dict(provider=None))
+        with self.assertRaises(AssertionError):
+            cognito.authenticate(dict(provider='myspace'))
+
+
+class TestEosLoadProviderDetails(unittest.TestCase):
+    def test_fails_if_provider_details_missing_or_wrong_type(self):
+        with self.assertRaises(InvalidRequestException):
+            cognito._load_provider_details(dict(token=None))
+        with self.assertRaises(InvalidRequestException):
+            cognito._load_provider_details(dict(token=34))
+        with self.assertRaises(InvalidRequestException):
+            cognito._load_provider_details(dict(token=[]))
+        with self.assertRaises(InvalidRequestException):
+            cognito._load_provider_details(dict(token='abc', other=3))
+
+    def test_loads_provider_details(self):
+        details = cognito._load_provider_details(dict(token='abc'))
+        self.assertEqual(details['token'], 'abc')
+
+
+class TestEosValidate(unittest.TestCase):
+    def test_fails_without_configuration(self):
+        with mock.patch('driftbase.auth.cognito.get_provider_config') as config:
+            config.return_value = None
+            with self.assertRaises(ServiceUnavailableException):
+                cognito._validate_cognito_token('abc')
+
+    def test_passes_configuration_to_implementation(self):
+        with mock.patch('driftbase.auth.cognito.get_provider_config') as config:
+            config.return_value = dict(
+                client_ids=['xyz'],
+                user_pool_region=TEST_USER_POOL_REGION,
+                user_pool_id=TEST_USER_POOL_ID
+            )
+            with mock.patch('driftbase.auth.cognito._run_cognito_token_validation') as validation:
+                validation.return_value = 0
+                cognito._validate_cognito_token('abc')
+                validation.assert_called_once_with('abc', ['xyz'], TEST_USER_POOL_REGION, TEST_USER_POOL_ID)
+
+
+class TestEosGetKeys(unittest.TestCase):
+    def test_fails_when_failing_to_load_keys(self):
+        with self.assertRaises(ServiceUnavailableException) as e:
+            cognito._get_key_from_token(TEST_JWT, 'https://invalid.com/region/userpool/index.html')
+            self.assertTrue(e.exception.msg.find('Failed to fetch') != -1)
+
+    def test_fails_when_key_set_is_empty(self):
+        with mock.patch('driftbase.auth.cognito.jwt.PyJWKClient') as mock_jwk_client:
+            instance = mock_jwk_client.return_value
+            instance.fetch_data.return_value = json.loads('{}')
+            instance.get_signing_key_from_jwt.return_value = None
+            with self.assertRaises(UnauthorizedException) as e:
+                cognito._get_key_from_token(TEST_JWT, driftbase.auth.cognito.COGNITO_PUBLIC_KEYS_URL_TEMPLATE)
+                self.assertTrue(e.exception.msg.find('Failed to find') != -1)
+
+    def test_fails_when_key_set_is_invalid(self):
+        with mock.patch.object(cognito.jwt.PyJWKClient, 'fetch_data') as mock_fetch:
+            mock_fetch.side_effect = json.decoder.JSONDecodeError('mock', '', 42)
+            with self.assertRaises(ServiceUnavailableException) as e:
+                cognito._get_key_from_token(TEST_JWT, driftbase.auth.cognito.COGNITO_PUBLIC_KEYS_URL_TEMPLATE)
+                self.assertTrue(e.exception.msg.find('Failed to read') != -1)
+
+
+@mock.patch('driftbase.auth.cognito.JWT_ALGORITHM', TEST_JWT_ALGORITHM)
+class TestEosRunAuthentication(unittest.TestCase):
+    def setUp(self):
+        self.token_audience = 'foo'
+        self.valid_client_ids = [self.token_audience]
+        self.expected_sub = 'cognito_account_id'
+
+    def test_decodes_and_validates_the_sub(self):
+        payload = dict(aud=self.token_audience, iss=cognito.TRUSTED_ISSUER_URL_BASE, sub=self.expected_sub)
+        token, jwk = _make_test_token_and_key(payload)
+        with mock.patch('driftbase.auth.cognito._get_key_from_token', return_value=jwk.key):
+            self.assertEqual(cognito._run_cognito_token_validation(token, self.valid_client_ids, TEST_USER_POOL_REGION,
+                                                                   TEST_USER_POOL_ID), self.expected_sub)
+
+    def test_fails_when_audience_is_missing(self):
+        payload = dict(iss=cognito.TRUSTED_ISSUER_URL_BASE, sub=self.expected_sub)
+        token, jwk = _make_test_token_and_key(payload)
+        with mock.patch('driftbase.auth.cognito._get_key_from_token', return_value=jwk.key):
+            with self.assertRaises(UnauthorizedException):
+                cognito._run_cognito_token_validation(token, self.valid_client_ids, TEST_USER_POOL_REGION,
+                                                      TEST_USER_POOL_ID), self.expected_sub
+
+    def test_fails_when_audience_is_wrong(self):
+        payload = dict(aud='other', iss=cognito.TRUSTED_ISSUER_URL_BASE, sub=self.expected_sub)
+        token, jwk = _make_test_token_and_key(payload)
+        with mock.patch('driftbase.auth.cognito._get_key_from_token', return_value=jwk.key):
+            with self.assertRaises(UnauthorizedException):
+                cognito._run_cognito_token_validation(token, self.valid_client_ids, TEST_USER_POOL_REGION,
+                                                      TEST_USER_POOL_ID), self.expected_sub
+
+    def test_fails_when_issuer_is_missing(self):
+        payload = dict(aus=self.token_audience, sub=self.expected_sub)
+        token, jwk = _make_test_token_and_key(payload)
+        with mock.patch('driftbase.auth.cognito._get_key_from_token', return_value=jwk.key):
+            with self.assertRaises(UnauthorizedException):
+                cognito._run_cognito_token_validation(token, self.valid_client_ids, TEST_USER_POOL_REGION,
+                                                      TEST_USER_POOL_ID), self.expected_sub
+
+    def test_fails_when_issuer_is_wrong(self):
+        payload = dict(aus=self.token_audience, iss='Acme Industries', sub=self.expected_sub)
+        token, jwk = _make_test_token_and_key(payload)
+        with mock.patch('driftbase.auth.cognito._get_key_from_token', return_value=jwk.key):
+            with self.assertRaises(UnauthorizedException):
+                cognito._run_cognito_token_validation(token, self.valid_client_ids, TEST_USER_POOL_REGION,
+                                                      TEST_USER_POOL_ID), self.expected_sub
+
+    def test_fails_when_keys_cannot_be_accessed(self):
+        payload = dict(aus=self.token_audience, iss=cognito.TRUSTED_ISSUER_URL_BASE, sub=self.expected_sub)
+        token, jwk = _make_test_token_and_key(payload)
+        with mock.patch('driftbase.auth.cognito._get_key_from_token', side_effect=ServiceUnavailableException("")):
+            with self.assertRaises(ServiceUnavailableException):
+                cognito._run_cognito_token_validation(token, self.valid_client_ids, TEST_USER_POOL_REGION,
+                                                      TEST_USER_POOL_ID), self.expected_sub
+
+    def test_fails_when_key_cannot_be_found(self):
+        payload = dict(aus=self.token_audience, iss=cognito.TRUSTED_ISSUER_URL_BASE, sub=self.expected_sub)
+        token, jwk = _make_test_token_and_key(payload)
+        with mock.patch('driftbase.auth.cognito._get_key_from_token', side_effect=UnauthorizedException("")):
+            with self.assertRaises(UnauthorizedException):
+                cognito._run_cognito_token_validation(token, self.valid_client_ids, TEST_USER_POOL_REGION,
+                                                      TEST_USER_POOL_ID), self.expected_sub
+
+
+def _make_test_token_and_key(payload):
+    jwk = jwt.PyJWK.from_json(TEST_JWK)
+    return jwt.encode(payload=payload, key=jwk.key, algorithm=TEST_JWT_ALGORITHM), jwk
+
+
+@mock.patch('driftbase.auth.cognito.JWT_ALGORITHM', TEST_JWT_ALGORITHM)
+class ProviderDetailsTests(BaseAuthTestCase):
+    def setUp(self):
+        self.token_audience = 'foo'
+        self.valid_client_ids = [self.token_audience]
+        self.expected_sub = 'cognito_account_id'
+
+    @staticmethod
+    def make_provider_data(token):
+        return {
+            'provider': 'cognito',
+            'provider_details': {
+                'token': token,
+            }
+        }
+
+    def test_auth(self):
+        with mock.patch('driftbase.auth.cognito.get_provider_config') as config:
+            config.return_value = dict(client_ids=[self.token_audience])
+            test_cognito_account_id = pbkdf2_hmac('sha256', self.expected_sub.encode('utf-8'),
+                                                  b'static_salt', iterations=1).hex()
+            payload = dict(aud=self.token_audience, iss=cognito.TRUSTED_ISSUER_URL_BASE, sub=self.expected_sub)
+            token, jwk = _make_test_token_and_key(payload)
+            with mock.patch('driftbase.auth.cognito._get_key_from_token', return_value=jwk.key):
+                user1 = self._auth_and_get_user(self.make_provider_data(token))
+            token, jwk = _make_test_token_and_key(payload)
+            with mock.patch('driftbase.auth.cognito._get_key_from_token', return_value=jwk.key):
+                user2 = self._auth_and_get_user(self.make_provider_data(token))
+            assert user1['identity_id'] == user2['identity_id']
+            assert user1['user_id'] == user2['user_id']
+            assert user1['provider_user_id'] == user2['provider_user_id']
+            assert user1['provider_user_id'] == f"cognito:{test_cognito_account_id}"

--- a/tests/auth/test_cognito.py
+++ b/tests/auth/test_cognito.py
@@ -24,7 +24,7 @@ TEST_USER_POOL_REGION = 'us-west-2'
 TEST_USER_POOL_ID = 'us-west-2_abc123'
 
 
-class TestEosAuthenticate(unittest.TestCase):
+class TestCognitoAuthenticate(unittest.TestCase):
     def test_fails_if_missing_or_incorrect_provider_name(self):
         with self.assertRaises(KeyError):
             cognito.authenticate(dict())
@@ -34,7 +34,7 @@ class TestEosAuthenticate(unittest.TestCase):
             cognito.authenticate(dict(provider='myspace'))
 
 
-class TestEosLoadProviderDetails(unittest.TestCase):
+class TestCognitoLoadProviderDetails(unittest.TestCase):
     def test_fails_if_provider_details_missing_or_wrong_type(self):
         with self.assertRaises(InvalidRequestException):
             cognito._load_provider_details(dict(token=None))
@@ -50,7 +50,7 @@ class TestEosLoadProviderDetails(unittest.TestCase):
         self.assertEqual(details['token'], 'abc')
 
 
-class TestEosValidate(unittest.TestCase):
+class TestCognitoValidate(unittest.TestCase):
     def test_fails_without_configuration(self):
         with mock.patch('driftbase.auth.cognito.get_provider_config') as config:
             config.return_value = None
@@ -70,7 +70,7 @@ class TestEosValidate(unittest.TestCase):
                 validation.assert_called_once_with('abc', ['xyz'], TEST_USER_POOL_REGION, TEST_USER_POOL_ID)
 
 
-class TestEosGetKeys(unittest.TestCase):
+class TestCognitoGetKeys(unittest.TestCase):
     def test_fails_when_failing_to_load_keys(self):
         with self.assertRaises(ServiceUnavailableException) as e:
             cognito._get_key_from_token(TEST_JWT, 'https://invalid.com/region/userpool/index.html')
@@ -94,7 +94,7 @@ class TestEosGetKeys(unittest.TestCase):
 
 
 @mock.patch('driftbase.auth.cognito.JWT_ALGORITHM', TEST_JWT_ALGORITHM)
-class TestEosRunAuthentication(unittest.TestCase):
+class TestCognitoRunAuthentication(unittest.TestCase):
     def setUp(self):
         self.token_audience = 'foo'
         self.valid_client_ids = [self.token_audience]


### PR DESCRIPTION
Add support for authentication via AWS Cognito User Pool ID Tokens.

This is more or less a copy of the EOS auth provider, since both are OAuth2 token based.

We should consolidate this into a single parameterizable provider to get automatic support for any OAuth2 provider in the future.