### PR TITLE
Apply matchmaking queue ban if any party member is banned

### DIFF
--- a/driftbase/api/matchmakers/flexmatch.py
+++ b/driftbase/api/matchmakers/flexmatch.py
@@ -139,6 +139,16 @@ class FlexMatchTicketsAPI(MethodView):
             log.info(f"Cannot start matchmaking for banned player {player_id}. Expires at: {unban_date}")
             return abort(http_client.FORBIDDEN, description=f"type=unban_date date={unban_date.isoformat()}")
 
+        # Cannot start matchmaking if any player member is banned.
+        party_id, party_members = flexmatch.get_player_party_and_members(player_id)
+        if party_id:
+            for member_id, member_name in party_members:
+                info = flexmatch.get_player_ban_info(member_id, matchmaker)
+                if info:
+                    unban_date = info["unban_date"]
+                    log.info(f"Cannot start matchmaking for banned player {member_id} in party {party_id}. Expires at: {unban_date}")
+                    return abort(http_client.FORBIDDEN, description=f"type=unban_date date={unban_date.isoformat()} party_member={member_name}")
+
         try:
             ticket = flexmatch.upsert_flexmatch_ticket(player_id, matchmaker, args.get("extras", {}))
             return {

--- a/driftbase/api/matchmakers/flexmatch.py
+++ b/driftbase/api/matchmakers/flexmatch.py
@@ -137,7 +137,7 @@ class FlexMatchTicketsAPI(MethodView):
         if info:
             unban_date = info["unban_date"]
             log.info(f"Cannot start matchmaking for banned player {player_id}. Expires at: {unban_date}")
-            return abort(http_client.FORBIDDEN, description=f"Matchmaking ban expires at: {unban_date.isoformat()}")
+            return abort(http_client.FORBIDDEN, description=f"type=unban_date date={unban_date.isoformat()}")
 
         try:
             ticket = flexmatch.upsert_flexmatch_ticket(player_id, matchmaker, args.get("extras", {}))

--- a/driftbase/flexmatch.py
+++ b/driftbase/flexmatch.py
@@ -846,7 +846,14 @@ class BanInfo(object):
         value = g.redis.conn.get(self._key)
         if value is not None:
             self._value = json.loads(value)
+        self._post_value_loaded()
         return self
+
+    def _post_value_loaded(self):
+        if self._value:
+            last_ban_date = self._value.get("last_ban_date")
+            if isinstance(date, str):
+                self._value["last_ban_date"] = datetime.fromisoformat(last_ban_date)
 
     def __exit__(self, exc_type, exc_val, exc_tb):
         if self._lock.owned():

--- a/driftbase/flexmatch.py
+++ b/driftbase/flexmatch.py
@@ -280,6 +280,7 @@ def get_player_ban_info(player_id: int, matchmaker: str, banned_only: bool = Tru
                     "num_bans": ban_info.num_bans,
                     "last_ban_date": ban_info.last_ban_date,
                     "expiry_date": ban_info.get_expiry_date()}
+    return None
 
 
 def process_flexmatch_event(flexmatch_event):

--- a/tests/test_flexmatch.py
+++ b/tests/test_flexmatch.py
@@ -366,6 +366,7 @@ class FlexMatchTest(_BaseFlexmatchTest):
                     self._value = self._store.get(self._key)
                     if not self.exists():
                         self._value = None
+                    self._post_value_loaded()
                     return self
                 def __exit__(self, exc_type, exc_val, exc_tb):
                     if self._modified is True and exc_type is None:


### PR DESCRIPTION
This commit ensures that if any player in a party is banned, the entire party will be prevented from entering the matchmaking queue. The ban status of each party member is now checked before allowing them to participate in matchmaking.

Also updated error description with an easier to parse format and include the banned party member name.

Edit:
Ban time check and datetime type fix.