### PR TITLE
Hotfix/event with no player id

### DIFF
--- a/driftbase/api/events.py
+++ b/driftbase/api/events.py
@@ -63,7 +63,7 @@ class EventsAPI(MethodView):
         # The event log API should enforce the player_id to the current player, unless
         # the user has role "service" in which case it should only set the player_id if
         # it's not passed in the event.
-        player_id = current_user["player_id"]
+        player_id = current_user.get("player_id", "")
         is_service = "service" in current_user["roles"] or "game_service" in current_user["roles"]
 
         for event in events:


### PR DESCRIPTION
Hotfix when there is no player id in the current user in events