### PR TITLE
Hotfix/Use prefix search on matchmaker name when checking match bans.

### DIFF
--- a/driftbase/flexmatch.py
+++ b/driftbase/flexmatch.py
@@ -268,6 +268,7 @@ def handle_match_event(queue_name, event_data):
                 if ban_info.exists():
                     log.info(f"Player {player_id} ban info updated: ",
                              extra={"matchmaker": ban_info.matchmaker,
+                                    "match_type": match_type,
                                     "num_bans": ban_info.num_bans,
                                     "unban_date": ban_info.get_unban_date(),
                                     "expiry_date": ban_info.get_expiry_date()})
@@ -925,8 +926,8 @@ class BanInfo(object):
     @staticmethod
     def find_config(matchmaker, match_type):
         config = _get_flexmatch_config_value("matchmaker_ban_times")
-        if matchmaker:
-            return matchmaker, config.get(matchmaker, {})
+        if isinstance(matchmaker, str):
+            return next(((k, v) for k, v in config.items() if matchmaker.startswith(k)), ("", {}))
         return next(((k, v) for k, v in config.items() if match_type in v["match_types"]), ("", {}))
 
     def get_redis(self):

--- a/tests/test_flexmatch.py
+++ b/tests/test_flexmatch.py
@@ -399,11 +399,11 @@ class FlexMatchTest(_BaseFlexmatchTest):
 
             # Cannot start if matchmaker is banned.
             _on_match_ban_event("EMatchType::Ranked", 1)
-            ban_info = flexmatch.get_player_ban_info(self.player_id, "DG-Ranked")
+            ban_info = flexmatch.get_player_ban_info(self.player_id, "DG-Ranked-2-4-5")
             self.assertIsNotNone(ban_info)
             self.assertEqual(ban_info["num_bans"], 1)
             self.assertGreaterEqual(ban_info["unban_date"], ban_info["last_ban_date"] + timedelta(seconds=get_config_ban_time_seconds(ban_info["num_bans"] - 1)))
-            self.post(endpoint, data={"matchmaker": "DG-Ranked"}, expected_status_code=http_client.FORBIDDEN)
+            self.post(endpoint, data={"matchmaker": "DG-Ranked-111-222-666"}, expected_status_code=http_client.FORBIDDEN)
 
             # Make sure each player is only banned once in a match.
             _on_match_ban_event("EMatchType::Ranked", 1)


### PR DESCRIPTION
Use prefix search on matchmaker name when checking match bans.