### PR TITLE
Update Responses from `client_config` endpoint for easier parsing in the client

### DIFF
--- a/driftbase/api/client_configs.py
+++ b/driftbase/api/client_configs.py
@@ -23,10 +23,12 @@ def drift_init_extension(app, **kwargs):
     endpoints.init_app(app)
 
 
-class ClientConfigsResponse(ma.Schema):
-    client_configs = ma.fields.Dict(keys=ma.fields.Str(), values=ma.fields.Str(),
-                                    metadata=dict(description='Client configs'))
+class ClientConfigResponse(ma.Schema):
+    key = ma.fields.Str(required=True)
+    value = ma.fields.Str(required=True, default="")
 
+class ClientConfigsResponse(ma.Schema):
+    client_configs = ma.fields.Nested(ClientConfigResponse, many=True, metadata=dict(description='Client configs'))
 
 @bp.route("", endpoint="configs")
 class ClientConfigAPI(MethodView):
@@ -36,7 +38,16 @@ class ClientConfigAPI(MethodView):
     def get(self):
         log.info(f"Returning client configs of tenant {get_tenant_name()}")
         tenant_client_config = _get_client_configs()
-        return {"client_configs": tenant_client_config}
+
+        output = []
+        for config_key, config_value in tenant_client_config.items():
+            output_entry = {
+                "key": config_key,
+                "value": config_value
+            }
+            output.append(output_entry)
+
+        return {"client_configs": output}
 
 
 @endpoints.register

--- a/tests/test_client_configs.py
+++ b/tests/test_client_configs.py
@@ -24,11 +24,11 @@ class ClientConfigTest(DriftBaseTestCase):
         data = response.json()
 
         expected_output = {
-            "client_configs": {
-                "client_config_1": "URL",
-                "client_config_2": "1",
-                "client_config_3": "",
-                "client_config_4": "URL"
-            }
+            "client_configs": [
+                {"key": "client_config_1", "value": "URL"},
+                {"key": "client_config_2", "value": "1"},
+                {"key": "client_config_3", "value": ""},
+                {"key": "client_config_4", "value":  "URL"}
+            ]
         }
-        self.assertEqual(data, expected_output)
+        self.assertEqual(expected_output, data)


### PR DESCRIPTION
This updates the response returned by GET from the `client_configs` endpoint to allow for easier parsing in the UE client. 

Dealing with the dict itself in the client is turning out to be tricky as the TMap conversion of JSONArchive doesn't work and I've been unsuccessfully trying to fix it all day yesterday. 

The client_config endpoint is currently not used at all on the tenants, so there shouldn't be an issue modifying the response.  

PR for changes on DriftUE4Base can be found [here](https://github.com/directivegames/DriftUE4Base/pull/35)