### PR TITLE
Fix exception on get matches when called with service role.

### DIFF
--- a/driftbase/api/matches.py
+++ b/driftbase/api/matches.py
@@ -309,9 +309,9 @@ class MatchesAPI(MethodView):
                     match_players = []
                     for player_row in players_result:
                         if is_service:
-                            [match_player, core_player] = player_row
+                            [match_player, player_name] = player_row
                             player_record = match_player.as_dict()
-                            player_record["player_name"] = core_player.player_name if core_player else ""
+                            player_record["player_name"] = player_name or ""
                         else:
                             player_record = player_row._asdict()
                             player_record["player_name"] = player_record["player_name"] or ""


### PR DESCRIPTION
In my previous fix, I mistakenly assumed that the tuple item core_player was an object when it already represents the player's name. Renamed core_player to player_name to avoid confusion.