### PR TITLE
Feature/match query features

### DIFF
--- a/driftbase/api/matches.py
+++ b/driftbase/api/matches.py
@@ -203,7 +203,7 @@ class MatchesAPI(MethodView):
         Dump the DB rows out as json
         """
 
-        log.info(f"Fetching matches for player {current_user['player_id']} with args {args}")
+        log.info(f"Fetching matches for player {current_user.get('player_id')} with args {args}")
 
         is_service = current_user.get('is_service', False) or "service" in current_user["roles"]
 

--- a/driftbase/api/matches.py
+++ b/driftbase/api/matches.py
@@ -10,6 +10,8 @@ from drift.blueprint import Blueprint, abort
 
 from drift.core.extensions.jwt import current_user, requires_roles
 from drift.core.extensions.urlregistry import Endpoints
+from sqlalchemy import func
+
 from driftbase.matchqueue import process_match_queue
 from driftbase.models.db import Machine, Server, Match, MatchTeam, MatchPlayer, MatchQueuePlayer, CorePlayer
 from driftbase.utils import log_match_event
@@ -193,6 +195,7 @@ class MatchesAPI(MethodView):
         map_name = ma.fields.String()
         statistics_filter = ma.fields.String()
         details_filter = ma.fields.String()
+        start_date = ma.fields.Date()
 
     @bp.arguments(MatchesAPIGetQuerySchema, location='query')
     def get(self, args):
@@ -214,6 +217,7 @@ class MatchesAPI(MethodView):
             map_name = args.get("map_name")
             statistics_filter = args.get("statistics_filter")
             details_filter = args.get("details_filter")
+            start_date = args.get("start_date")
 
             if statistics_filter:
                 try:
@@ -261,6 +265,9 @@ class MatchesAPI(MethodView):
             if details_filter:
                 for key, value in details_filter.items():
                     matches_query = matches_query.filter(Match.details[key].astext == value)
+
+            if start_date:
+                matches_query = matches_query.filter(func.date(Match.start_date) == start_date)
 
             matches_query = matches_query.order_by(-Match.match_id)
 

--- a/driftbase/api/matches.py
+++ b/driftbase/api/matches.py
@@ -203,7 +203,7 @@ class MatchesAPI(MethodView):
         Dump the DB rows out as json
         """
 
-        log.info(f"Fetching matches for player {current_user.get('player_id')} with args {args}")
+        log.info(f"Fetching matches for player {current_user.get('player_id', 'service')} with args {args}")
 
         is_service = current_user.get('is_service', False) or "service" in current_user["roles"]
 

--- a/tests/test_matches.py
+++ b/tests/test_matches.py
@@ -1,3 +1,4 @@
+import datetime
 from collections import defaultdict
 
 import http.client as http_client
@@ -90,6 +91,24 @@ class MatchesTest(BaseMatchTest):
         self.assertIn("players", match)
         self.assertIn("teams", match)
 
+        # Get matches from date
+        resp = self.get("/matches", params={"use_pagination": True, "start_date": datetime.date.today().isoformat()})
+        resp_json = resp.json()
+
+        for m in resp_json["items"]:
+            self.assertEqual(datetime.datetime.fromisoformat(m["start_date"]).date(), datetime.date.today())
+
+        resp = self.get("/matches", params={"use_pagination": True,
+                                            "start_date": (datetime.date.today() - datetime.timedelta(1)).isoformat()})
+        resp_json = resp.json()
+
+        assert len(resp_json["items"]) == 0
+
+        resp = self.get("/matches", params={"use_pagination": True,
+                                            "start_date": (datetime.date.today() + datetime.timedelta(1)).isoformat()})
+        resp_json = resp.json()
+
+        assert len(resp_json["items"]) == 0
 
     def test_create_match(self):
         self.auth_service()


### PR DESCRIPTION
Add support for querying for matches on a specific date.
Don't fail when using using a service user without a player_id. player_id is only used by the logger.