### PR TITLE
[Rich Presence] Fix redis key scoping

### DIFF
--- a/driftbase/api/clients.py
+++ b/driftbase/api/clients.py
@@ -240,7 +240,7 @@ class ClientsAPI(MethodView):
         try:
             RichPresenceService(g.db, g.redis, current_user).set_online_status(player_id, True)
         except Exception as e:
-            log.exception(f"Failed to set online match status while registering client. {e}")
+            log.exception(f"Failed to set online status while registering client. {e}")
         return ret
 
 
@@ -353,7 +353,7 @@ class ClientAPI(MethodView):
         try:
             RichPresenceService(g.db, g.redis, current_user).set_online_status(player_id, False)
         except Exception as e:
-            log.exception(f"Failed to set clear match status during player-left-match. {e}")
+            log.exception(f"Failed to set online status during reregister client. {e}")
 
         return json_response("Client has been closed. Please terminate the client.",
                              http_client.OK)

--- a/driftbase/api/richpresence.py
+++ b/driftbase/api/richpresence.py
@@ -44,13 +44,8 @@ class RichPresenceAPI(MethodView):
         Retrieve rich-presence information for a specific player
         """
 
-        log.info(f"GetRichPrescene called with '{player_id}'")
-
         try:
-            response = RichPresenceService(g.db, g.redis, query_current_user()).get_richpresence(player_id)
-            log.info(f"GetRichPrescene: result={str(response)}")
-
-            return response
+            return RichPresenceService(g.db, g.redis, query_current_user()).get_richpresence(player_id)
         except DriftBaseException as e:
             log.warning(f"GetRichPrescene DriftBaseException: {e}")
             abort(e.error_code(), message=e.msg)

--- a/driftbase/api/richpresence.py
+++ b/driftbase/api/richpresence.py
@@ -12,10 +12,12 @@ from driftbase.richpresence import RichPresenceSchema, RichPresenceService
 from drift.core.extensions.urlregistry import Endpoints
 from flask import url_for, g
 from webargs.flaskparser import abort
-from drift.core.extensions.jwt import current_user
+import logging
+from drift.core.extensions.jwt import query_current_user
 
 bp = Blueprint("richpresence", __name__, url_prefix="/rich-presence/")
 endpoints = Endpoints()
+log = logging.getLogger(__name__)
 
 def drift_init_extension(app, **kwargs):
     app.register_blueprint(bp)
@@ -42,11 +44,18 @@ class RichPresenceAPI(MethodView):
         Retrieve rich-presence information for a specific player
         """
 
+        log.info(f"GetRichPrescene called with '{player_id}'")
+
         try:
-            return RichPresenceService(g.db, g.redis, current_user).get_richpresence(player_id)
+            response = RichPresenceService(g.db, g.redis, query_current_user()).get_richpresence(player_id)
+            log.info(f"GetRichPrescene: result={str(response)}")
+
+            return response
         except DriftBaseException as e:
+            log.warning(f"GetRichPrescene DriftBaseException: {e}")
             abort(e.error_code(), message=e.msg)
-        except Exception:
+        except Exception as e:
+            log.warning(f"GetRichPrescene Exception: {e}")
             abort(http_client.INTERNAL_SERVER_ERROR)
 
 

--- a/driftbase/counters.py
+++ b/driftbase/counters.py
@@ -17,7 +17,6 @@ MAX_RETRIES = 3
 
 log = logging.getLogger(__name__)
 
-
 def get_all_counters(force=False):
     def get_all_counters_from_db():
         counters = g.db.query(Counter).all()

--- a/driftbase/richpresence.py
+++ b/driftbase/richpresence.py
@@ -43,7 +43,7 @@ class RichPresenceSchema(Schema):
 class RichPresenceService():
     def __init__(self, db_session: Session, redis: RedisCache, local_user : dict) -> None:
         self.db_session = db_session
-        self.redis = redis.conn
+        self.redis = redis
         self.local_user = local_user
 
     def _get_friends(self, player_id) -> list[int]:
@@ -59,13 +59,11 @@ class RichPresenceService():
         return [row[2] for row in friend_rows]
 
     def _get_redis_key(self, player_id) -> str:
-        return f"rich_presence:{player_id}"
+        return self.redis.make_key(f"rich_presence:{player_id}")
     
     def _notify_rich_presence_changed(self, player_id):
         presence = self.get_richpresence(player_id)
         presence_json = RichPresenceSchema(many=False).dump(presence)
-
-        log.info(f"_notify_rich_presence_changed {player_id}: {str(presence_json)}")
 
         for receiver_id in self._get_friends(player_id):
             post_message("players", int(receiver_id), "richpresence", presence_json, sender_system=True)
@@ -86,52 +84,48 @@ class RichPresenceService():
             raise ForbiddenException("No access to player.")
         
         key = self._get_redis_key(player_id)
-        presence_dict = self.redis.hgetall(key)
+        presence_dict = self.redis.conn.hgetall(key)
 
-        log.info(f"get_richpresence (pre) key={key}, dict={str(presence_dict)}")
-
-        presence_dict['is_in_game'] = presence_dict.get('map_name') != "" or presence_dict.get('game_mode') != ""
+        presence_dict['is_in_game'] = presence_dict.get('map_name', "") != "" or presence_dict.get('game_mode', "") != ""
         presence_dict['player_id'] = player_id
-
-        log.info(f"get_richpresence (post) key={key}, dict={str(presence_dict)}")
 
         if presence_dict:
             return RichPresenceSchema(many=False).load(presence_dict)
         else:
             return PlayerRichPresence()
 
-    def set_online_status(self, player_id: int, is_online: bool):
+    def set_online_status(self, player_id: int, is_online: bool, send_notification=True) -> bool:
         """
         Sets the players online status, and updates rich-presence
         """
-        log.info("set_online_status")
 
         key = self._get_redis_key(player_id)
-        old_online = self.redis.hget(key, "is_online")
-        self.redis.hset(key, "is_online", int(is_online))
-
-        log.info(f"set_online_status {player_id}: old={old_online}, new={is_online}")
+        old_online = self.redis.conn.hget(key, "is_online")
+        self.redis.conn.hset(key, "is_online", int(is_online))
 
         if old_online != is_online:
-            self._notify_rich_presence_changed(player_id)
+            if send_notification:
+                self._notify_rich_presence_changed(player_id)
+            return True
+        return False
 
-    def set_match_status(self, player_id: int, map_name: str, game_mode: str):
+    def set_match_status(self, player_id: int, map_name: str, game_mode: str, send_notification=True) -> bool:
         """
         Sets the players match status, and updates rich-presence
         """
 
         key = self._get_redis_key(player_id)
-        old_game_mode = self.redis.hget(key, "game_mode")
-        old_map_name = self.redis.hget(key, "map_name")
+        old_game_mode = self.redis.conn.hget(key, "game_mode")
+        old_map_name = self.redis.conn.hget(key, "map_name")
 
-        self.redis.hset(key, "game_mode", game_mode)
-        self.redis.hset(key, "map_name", map_name)
-
-        log.info(f"set_match_status game_mode {player_id}: old={old_game_mode}, new={game_mode}")
-        log.info(f"set_match_status map_name {player_id}: old={old_map_name}, new={map_name}")
+        self.redis.conn.hset(key, "game_mode", game_mode)
+        self.redis.conn.hset(key, "map_name", map_name)
 
         if old_game_mode != game_mode or old_map_name != map_name:
-            self._notify_rich_presence_changed(player_id)
+            if send_notification:
+                self._notify_rich_presence_changed(player_id)
+            return True
+        return False
 
 
     def clear_match_status(self, player_id : int) -> None:
@@ -146,5 +140,8 @@ class RichPresenceService():
         clients.
         """
 
-        self.set_match_status(player_id, presence.map_name, presence.game_mode)
-        self.set_online_status(player_id, presence.is_online)
+        match_status_changed = self.set_match_status(player_id, presence.map_name, presence.game_mode, False)
+        online_status_changed = self.set_online_status(player_id, presence.is_online, False)
+
+        if match_status_changed or online_status_changed:
+            self._notify_rich_presence_changed(player_id)

--- a/driftbase/utils/exceptions.py
+++ b/driftbase/utils/exceptions.py
@@ -9,29 +9,29 @@ class DriftBaseException(Exception):
     def __init__(self, user_message):
         super().__init__(user_message)
         self.msg = user_message
-    def error_code():
+    def error_code(self):
         return http_client.INTERNAL_SERVER_ERROR
 
 class InvalidRequestException(DriftBaseException):
-    def error_code():
+    def error_code(self):
         return http_client.BAD_REQUEST
 
 class NotFoundException(DriftBaseException):
-    def error_code():
+    def error_code(self):
         return http_client.NOT_FOUND
 
 class UnauthorizedException(DriftBaseException):
-    def error_code():
+    def error_code(self):
         return http_client.UNAUTHORIZED
 
 class ConflictException(DriftBaseException):
-    def error_code():
+    def error_code(self):
         return http_client.CONFLICT
 
 class ForbiddenException(DriftBaseException):
-    def error_code():
+    def error_code(self):
         return http_client.FORBIDDEN
 
 class TryLaterException(DriftBaseException):
-    def error_code():
+    def error_code(self):
         return http_client.SERVICE_UNAVAILABLE

--- a/driftbase/utils/exceptions.py
+++ b/driftbase/utils/exceptions.py
@@ -9,19 +9,24 @@ class DriftBaseException(Exception):
     def __init__(self, user_message):
         super().__init__(user_message)
         self.msg = user_message
-    def error_code(self):
+
+    @staticmethod
+    def error_code():
         return http_client.INTERNAL_SERVER_ERROR
 
 class InvalidRequestException(DriftBaseException):
-    def error_code(self):
+    @staticmethod
+    def error_code():
         return http_client.BAD_REQUEST
 
 class NotFoundException(DriftBaseException):
-    def error_code(self):
+    @staticmethod
+    def error_code():
         return http_client.NOT_FOUND
 
 class UnauthorizedException(DriftBaseException):
-    def error_code(self):
+    @staticmethod
+    def error_code():
         return http_client.UNAUTHORIZED
 
 class ConflictException(DriftBaseException):
@@ -29,9 +34,11 @@ class ConflictException(DriftBaseException):
         return http_client.CONFLICT
 
 class ForbiddenException(DriftBaseException):
-    def error_code(self):
+    @staticmethod
+    def error_code():
         return http_client.FORBIDDEN
 
 class TryLaterException(DriftBaseException):
-    def error_code(self):
+    @staticmethod
+    def error_code():
         return http_client.SERVICE_UNAVAILABLE

--- a/tests/test_richpresence.py
+++ b/tests/test_richpresence.py
@@ -42,7 +42,9 @@ class RichPresenceTest(BaseCloudkitTest):
         client_url = r.json()["url"]
 
         # Ensure client is considered online
-        self.assertTrue(self._get_player_richpresence(player_id)['is_online'])
+        rich_presence = self._get_player_richpresence(player_id)
+        self.assertTrue(rich_presence['is_online'])
+        self.assertFalse(rich_presence['is_in_game'])
 
         # Update our authorization to a client session
         jti = r.json()["jti"]
@@ -53,6 +55,7 @@ class RichPresenceTest(BaseCloudkitTest):
 
         # Ensure client is considered offline post deletion
         self.assertFalse(self._get_player_richpresence(player_id)['is_online'])
+        
 
     def test_richpresence_match_update(self):
         """

--- a/tests/test_richpresence.py
+++ b/tests/test_richpresence.py
@@ -4,14 +4,16 @@ from driftbase.richpresence import RichPresenceService
 from driftbase.richpresence import PlayerRichPresence, RichPresenceSchema
 from flask import url_for, g
 from driftbase.utils.exceptions import ForbiddenException, NotFoundException
+import uuid
 
-class RichPresenceTest(BaseCloudkitTest):
-    """
-    Tests for the /rich-presence endpoints and related implementation.
-    """
-
+class BaseRichPresenceTest(BaseCloudkitTest):
+        
+    def _make_named_player(self, username, player_name=None):
+        self.auth(username=username, player_name=player_name)
+        self.patch(self.endpoints['my_player'], data={"name": player_name or username})
+        return self.player_id
+        
     def _get_player_richpresence(self, player_id : int) -> dict:
-        self.auth()
         url = self.endpoints['template_richpresence'].replace("{player_id}", str(player_id))
         return self.get(url).json()
 
@@ -19,14 +21,22 @@ class RichPresenceTest(BaseCloudkitTest):
         with self._request_context():
             return url_for("messages.message", exchange_id=player_id, exchange="players", queue="richpresence", message_id=message_id, _external=True)
 
+    def _make_user_name(self, name):
+        return "{}.{}".format(str(uuid.uuid4())[:8], name)
+
+
+class RichPresenceIsOnline(BaseRichPresenceTest):
     def test_richpresence_is_online(self):
         """
         Test that a player will become online based on his client status
         """
 
+        username = self._make_user_name("a")
+
         # Create a client
-        self.auth()
+        self._make_named_player(username)
         player_id = self.player_id
+
         clients_uri = self.endpoints["clients"]
         platform_version = "1.20.22"
         data = {
@@ -43,8 +53,8 @@ class RichPresenceTest(BaseCloudkitTest):
 
         # Ensure client is considered online
         rich_presence = self._get_player_richpresence(player_id)
-        self.assertTrue(rich_presence['is_online'])
-        self.assertFalse(rich_presence['is_in_game'])
+        self.assertTrue(rich_presence['is_online'], "is_online should be true for online client.")
+        self.assertFalse(rich_presence['is_in_game'], "is_in_game should be false for online client.")
 
         # Update our authorization to a client session
         jti = r.json()["jti"]
@@ -54,16 +64,19 @@ class RichPresenceTest(BaseCloudkitTest):
         self.delete(client_url)
 
         # Ensure client is considered offline post deletion
-        self.assertFalse(self._get_player_richpresence(player_id)['is_online'])
-        
+        rich_presence = self._get_player_richpresence(player_id)
+        self.assertFalse(rich_presence['is_online'], "is_online should be false for offline client.")
+        self.assertFalse(rich_presence['is_in_game'], "is_online should be false for offline client.")
 
+class RichPresenceMatchUpdate(BaseRichPresenceTest):
     def test_richpresence_match_update(self):
         """
         Tests that the players rich presence is updated when he joins a match, and when he leaves
         a match.
         """
 
-        self.auth()
+        username = "test_richpresence_match_update"
+        self.auth(username=username)
         player_id = self.player_id
         team_id = 0
 
@@ -86,6 +99,7 @@ class RichPresenceTest(BaseCloudkitTest):
         resp = self.post(matchplayers_url, data=data, expected_status_code=http_client.CREATED).json()
         matchplayer_url = resp["url"]
 
+        self.auth(username=username)
         res = self._get_player_richpresence(player_id)
 
         # If these starts failing, check the defaults in _create_match
@@ -97,23 +111,27 @@ class RichPresenceTest(BaseCloudkitTest):
         self.auth_service()
         self.delete(matchplayer_url, expected_status_code=http_client.OK)
 
+        self.auth(username=username)
+
         res = self._get_player_richpresence(player_id)
         self.assertEqual(res['map_name'], "")
         self.assertEqual(res['game_mode'], "")
         self.assertEqual(res['is_in_game'], False)
 
+class RichPresenceMessageQueue(BaseRichPresenceTest):
     def test_richpresence_messagequeue(self):
         """
         Tests that updating rich-presence will send a message to your friends.
         """
-                
+        
+        friend_username = self._make_user_name("f")
+        self_username = self._make_user_name("s")
+
         # Setup players
-        self.auth(username="player_friend")
-        friend_id = self.player_id
+        friend_id = self._make_named_player(friend_username)
         friend_token = self.post(self.endpoints["friend_invites"], expected_status_code=http_client.CREATED).json()["token"]
 
-        self.auth(username="player_self")
-        player_id = self.player_id
+        player_id = self._make_named_player(self_username)
 
         # Create friend relationship
         self.post(self.endpoints["my_friends"], data={"token": friend_token}, expected_status_code=http_client.CREATED)
@@ -126,14 +144,18 @@ class RichPresenceTest(BaseCloudkitTest):
                 "player_id": player_id
             }
             RichPresenceService(g.db, g.redis, current_user_mock).set_richpresence(friend_id, presence)
-            self.assertTrue(presence, RichPresenceService(g.db, g.redis, current_user_mock).get_richpresence(friend_id))
+            
+            res = RichPresenceService(g.db, g.redis, current_user_mock).get_richpresence(friend_id)
+            self.assertEqual(presence, res)
 
         # Ensure that the message was recieved, and matches expected presence
         url = self._get_message_queue_url(player_id)
         payload = self.get(url).json()["payload"]
 
-        self.assertEqual(presence, RichPresenceSchema(many=False).load(payload))
+        res = RichPresenceSchema(many=False).load(payload)
+        self.assertEqual(presence, res)
 
+class RichPresenceNoAccess(BaseRichPresenceTest):
     def test_richpresence_noaccess(self):
         """
         Tests that it's impossible to get rich-presence information for non-friends.


### PR DESCRIPTION

This follow up PR includes my fixes after testing and verifying with Bruno and the client:

1) The 'sender id' cannot be extracted from the message queue, because the sender is the system. I've updated the payload to include this information.
2) The keys for the richpresence were not properly scoped, causing havoc in tests, and in theory at runtime.

This will be paired with a client update, which handles some more fixes, including logging the player out when Unreal exits.
