### PR TITLE
Allow 'service' to access rich presence

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,6 +63,10 @@
 
 ---
 
+## 0.22.4
+
+ - Fixes match-presence unavailable due to service not having access to query rich presence
+
 ## 0.22.3
 ## 0.22.2
 ## 0.22.1

--- a/driftbase/richpresence.py
+++ b/driftbase/richpresence.py
@@ -79,7 +79,11 @@ class RichPresenceService():
             log.warning("get_richpresence: Player does not exist.")
             raise NotFoundException("Player does not exist.")
         
-        if player_id != local_player and player_id not in self._get_friends(local_player):
+        is_service = 'service' in self.local_user.get('roles', [])
+        is_local_player = player_id == local_player
+        is_friend = player_id in self._get_friends(local_player)
+
+        if not (is_service or is_local_player or is_friend):
             log.warning("get_richpresence: No access to player.")
             raise ForbiddenException("No access to player.")
         

--- a/tests/test_richpresence.py
+++ b/tests/test_richpresence.py
@@ -173,12 +173,22 @@ class RichPresenceNoAccess(BaseRichPresenceTest):
         self.auth(username="non_friend")
         non_friend = self.player_id
 
+        ## Test with player role
         with self._request_context():
             current_user_mock = {
-                "player_id": player_id
+                "player_id": player_id,
+                "roles": ["player"]
             }
             self.assertRaises(ForbiddenException, RichPresenceService(g.db, g.redis, current_user_mock).get_richpresence, non_friend)
 
-            
+        ## Test with system role
+        with self._request_context():
+            current_user_mock = {
+                "player_id": player_id,
+                "roles": ["service"]
+            }
 
-        
+            try:
+                RichPresenceService(g.db, g.redis, current_user_mock).get_richpresence(non_friend)
+            except ForbiddenException:
+                self.fail("get_richpresence raised RichPresenceService as a system")


### PR DESCRIPTION
This PR fixes an issue where calls to match presence were failing, since they were originating from a service (not a user), and therefor rich presence was throwing a no access exception.