### PR TITLE
Fix race condition when creating users and identities

### DIFF
--- a/driftbase/models/db.py
+++ b/driftbase/models/db.py
@@ -90,6 +90,7 @@ class UserIdentity(ModelBase):
     __tablename__ = "ck_user_identities"
 
     identity_id = Column(Integer, primary_key=True)
+    # FIXME: Figure out why name has no unique constraint
     name = Column(String(200), index=True)
     identity_type = Column(String(50), index=True)
     password_hash = Column(String(200))


### PR DESCRIPTION
- Background: When someone tries to login with a new user several times in parallel, it's possible that multiple identities and users are created. It's then random which one is going to be used for the next login. Since users and players are created in the same flow, we must lock around the entire thing, but we lock on the username, so it should not affect the flow for different users. This seems deterministic at first, but when the index is rebalanced on the table, the order of the returned identities may suddenly change.
- In addition, where there are multiple user identities, we now return the one which has the most logins, as that will fix the current issue for players quickly.