### PR TITLE
support blacklist to block certain events from being shout out

### DIFF
--- a/driftbase/api/events.py
+++ b/driftbase/api/events.py
@@ -30,7 +30,7 @@ def drift_init_extension(app, **kwargs):
     endpoints.init_app(app)
 
 
-default_eventlog_config = dict(eventlog=dict(max_batch_size=5, events_blacklist=[]))
+default_eventlog_config = dict(eventlog=dict(max_batch_size=5, events_blacklist=['drift.*']))
 
 
 def _get_shoutout():

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -142,10 +142,18 @@ class EventsTest(DriftBaseTestCase):
         ts = datetime.datetime.now().isoformat() + "Z"
         with mock.patch("driftbase.api.events._get_shoutout", return_value=shoutout_mock):
             with mock.patch("driftbase.api.events.get_feature_switch", return_value=True):
-                # no blacklist
+                # default blacklist
                 self.post(
                     endpoint,
                     data=[{"hello": "world", "event_name": "drift.blah", "timestamp": ts}],
+                    expected_status_code=http_client.CREATED,
+                )
+                shoutout_mock.message.assert_not_called()
+                shoutout_mock.reset_mock()
+                
+                self.post(
+                    endpoint,
+                    data=[{"hello": "world", "event_name": "player.battle.damage_dealt", "timestamp": ts}],
                     expected_status_code=http_client.CREATED,
                 )
                 shoutout_mock.message.assert_called_once()

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -142,7 +142,7 @@ class EventsTest(DriftBaseTestCase):
         ts = datetime.datetime.now().isoformat() + "Z"
         with mock.patch("driftbase.api.events._get_shoutout", return_value=shoutout_mock):
             with mock.patch("driftbase.api.events.get_feature_switch", return_value=True):
-                # default blacklist
+                # default block list
                 self.post(
                     endpoint,
                     data=[{"hello": "world", "event_name": "drift.blah", "timestamp": ts}],
@@ -159,10 +159,10 @@ class EventsTest(DriftBaseTestCase):
                 shoutout_mock.message.assert_called_once()
                 shoutout_mock.reset_mock()
                 
-                # with blacklist
+                # with block list
                 with mock.patch(
                     "driftbase.api.events.default_eventlog_config",
-                    dict(eventlog=dict(max_batch_size=5, events_blacklist=["drift.*", "player.battle.damage_dealt"])),
+                    dict(eventlog=dict(max_batch_size=5, shoutout_block_list=["drift.*", "player.battle.damage_dealt"])),
                 ):
                     self.post(
                         endpoint,


### PR DESCRIPTION
to support drift config being something like:
```
"eventlog": {
    "max_batch_size": 10,
    "events_blacklist": ["drift.*", "player.battle.damage_dealt"]
},
```